### PR TITLE
[volume-6] Resilience 적용하여 결제 기능 안정화

### DIFF
--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -22,4 +22,6 @@ dependencies {
 
     // test-fixtures
     testImplementation(testFixtures(project(":modules:jpa")))
+
+    implementation("org.apache.httpcomponents.client5:httpclient5")
 }

--- a/apps/commerce-api/build.gradle.kts
+++ b/apps/commerce-api/build.gradle.kts
@@ -16,6 +16,10 @@ dependencies {
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
 
+    // resilience4j
+    implementation("io.github.resilience4j:resilience4j-spring-boot3")
+    implementation("org.springframework.boot:spring-boot-starter-aop")
+
     // test-fixtures
     testImplementation(testFixtures(project(":modules:jpa")))
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/coupon/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/coupon/CouponService.java
@@ -2,6 +2,8 @@ package com.loopers.application.coupon;
 
 import com.loopers.domain.coupon.Coupon;
 import com.loopers.domain.coupon.CouponRepository;
+import com.loopers.support.error.CommonErrorType;
+import com.loopers.support.error.CoreException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -20,6 +22,7 @@ public class CouponService {
     }
 
     public Coupon getCouponId(Long couponId) {
-        return couponRepository.findById(couponId);
+        return couponRepository.findById(couponId).orElseThrow(() ->
+                new CoreException(CommonErrorType.NOT_FOUND, "쿠폰을 찾을 수 없습니다. couponId: " + couponId));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/couponmember/CouponMemberService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/couponmember/CouponMemberService.java
@@ -2,6 +2,8 @@ package com.loopers.application.couponmember;
 
 import com.loopers.domain.couponmember.CouponMember;
 import com.loopers.domain.couponmember.CouponMemberRepository;
+import com.loopers.support.error.CommonErrorType;
+import com.loopers.support.error.CoreException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -26,7 +28,8 @@ public class CouponMemberService {
      * 쿠폰 조회
      * */
     public CouponMember getCouponMemberById(Long memberId, Long couponId) {
-        return couponMemberRepository.findByCouponIdAndMemberId(couponId, memberId);
+        return couponMemberRepository.findByCouponIdAndMemberId(couponId, memberId).
+                orElseThrow(() -> new CoreException(CommonErrorType.BAD_REQUEST, "쿠폰을 찾을 수 없습니다. couponId: " + couponId + ", memberId: " + memberId));
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/orderItem/service/OrderItemService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orderItem/service/OrderItemService.java
@@ -2,6 +2,8 @@ package com.loopers.application.orderItem.service;
 
 import com.loopers.domain.orderItem.OrderItem;
 import com.loopers.domain.orderItem.OrderItemRepository;
+import com.loopers.support.error.CommonErrorType;
+import com.loopers.support.error.CoreException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,5 +19,10 @@ public class OrderItemService {
 
     public void register(List<OrderItem> orderItems) {
         orderItemRepository.saveAll(orderItems);
+    }
+
+    public OrderItem findByOrderId(Long orderId) {
+        return orderItemRepository.findByOrdersId(orderId)
+                .orElseThrow(() -> new CoreException(CommonErrorType.NOT_FOUND, "주문 아이템을 찾을 수 없습니다. orderId: " + orderId));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/command/PlaceOrderCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/command/PlaceOrderCommand.java
@@ -1,5 +1,7 @@
 package com.loopers.application.orders.command;
 
+import com.loopers.domain.payment.CardType;
+import com.loopers.domain.payment.PaymentType;
 import com.loopers.support.error.CommonErrorType;
 import com.loopers.support.error.CoreException;
 import lombok.AccessLevel;
@@ -16,20 +18,26 @@ public class PlaceOrderCommand {
     private Long memberId;
     private List<Item> items;
     private Long couponId;
+    private PaymentType paymentType;
+    private CardType cardType;
+    private String cardNo;
 
-    private PlaceOrderCommand(Long memberId, List<Item> items, Long couponId) {
+    private PlaceOrderCommand(Long memberId, List<Item> items, Long couponId, PaymentType paymentType, CardType cardType, String cardNo) {
         this.memberId = memberId;
         this.items = items;
         this.couponId = couponId;
+        this.paymentType = paymentType;
+        this.cardType = cardType;
+        this.cardNo = cardNo;
     }
 
-    public static PlaceOrderCommand of(Long memberId, List<Item> items, Long couponId) {
-        validate(memberId, items, couponId);
+    public static PlaceOrderCommand of(Long memberId, List<Item> items, Long couponId, PaymentType paymentType, CardType cardType, String cardNo) {
+        validate(memberId, items, couponId, paymentType, cardType, cardNo);
 
-        return new PlaceOrderCommand(memberId, items, couponId);
+        return new PlaceOrderCommand(memberId, items, couponId, paymentType, cardType, cardNo);
     }
 
-    private static void validate(Long memberId, List<Item> items, Long couponId) {
+    private static void validate(Long memberId, List<Item> items, Long couponId, PaymentType paymentType, CardType cardType, String cardNo) {
         if (memberId == null || memberId <= 0) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "유효하지 않은 회원 ID입니다.");
         }
@@ -39,7 +47,21 @@ public class PlaceOrderCommand {
         if (couponId != null && couponId <= 0) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "유효하지 않은 쿠폰 ID입니다.");
         }
-        items.forEach(item -> itemValidate(item));
+        if (paymentType == null) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "결제 유형이 지정되지 않았습니다.");
+        }
+        if (!PaymentType.isValid(paymentType)) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "지원하지 않는 결제 유형입니다.");
+        }
+        if (paymentType == PaymentType.CARD) {
+            if (cardType != null && !CardType.isValid(cardType)) {
+                throw new CoreException(CommonErrorType.BAD_REQUEST, "지원하지 않는 카드 유형입니다.");
+            }
+            if (cardType != null && (cardNo == null || cardNo.isBlank() || !cardNo.matches("\\d{4}-\\d{4}-\\d{4}-\\d{4}"))) {
+                throw new CoreException(CommonErrorType.BAD_REQUEST, "유효하지 않은 카드 번호입니다. 형식은 xxxx-xxxx-xxxx-xxxx 입니다.");
+            }
+        }
+        items.forEach(PlaceOrderCommand::itemValidate);
     }
 
     public static void itemValidate(Item item) {
@@ -52,12 +74,6 @@ public class PlaceOrderCommand {
         if (item.getPrice() == null || item.getPrice().compareTo(BigDecimal.ZERO) <= 0) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "가격은 0 이상이어야 합니다.");
         }
-    }
-
-    public BigDecimal getTotalPrice() {
-        return items.stream()
-                .map(item -> item.getPrice().multiply(BigDecimal.valueOf(item.getQuantity())))
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
     }
 
     @Getter

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/result/OrdersRegisterInfoResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/result/OrdersRegisterInfoResult.java
@@ -14,7 +14,9 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrdersRegisterInfoResult {
 
-    private OrderStatus status;
+    private OrderStatus orderStatus;
+
+    private String paymentStatus;
 
     private LocalDateTime orderDate;
 
@@ -22,22 +24,26 @@ public class OrdersRegisterInfoResult {
 
     private int totalCount;
 
-    private OrdersRegisterInfoResult(OrderStatus status, LocalDateTime orderDate, BigDecimal totalPrice, int totalCount) {
-        this.status = status;
+    private OrdersRegisterInfoResult(OrderStatus orderStatus, String paymentStatus, LocalDateTime orderDate, BigDecimal totalPrice, int totalCount) {
+        this.orderStatus = orderStatus;
+        this.paymentStatus = paymentStatus;
         this.orderDate = orderDate;
         this.totalPrice = totalPrice;
         this.totalCount = totalCount;
     }
 
-    public static OrdersRegisterInfoResult of(OrderStatus status, LocalDateTime orderDate, BigDecimal totalPrice, int totalCount) {
-        validate(status, orderDate, totalPrice, totalCount);
+    public static OrdersRegisterInfoResult of(OrderStatus orderStatus, String paymentStatus, LocalDateTime orderDate, BigDecimal totalPrice, int totalCount) {
+        validate(orderStatus, paymentStatus, orderDate, totalPrice, totalCount);
 
-        return new OrdersRegisterInfoResult(status, orderDate, totalPrice, totalCount);
+        return new OrdersRegisterInfoResult(orderStatus, paymentStatus, orderDate, totalPrice, totalCount);
     }
 
-    private static void validate(OrderStatus status, LocalDateTime orderDate, BigDecimal totalPrice, int totalCount) {
-        if (status == null) {
+    private static void validate(OrderStatus orderStatus, String paymentStatus, LocalDateTime orderDate, BigDecimal totalPrice, int totalCount) {
+        if (orderStatus == null) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "주문 상태는 필수입니다.");
+        }
+        if (paymentStatus == null || paymentStatus.isEmpty()) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "결제 상태는 필수입니다.");
         }
         if (orderDate == null) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "주문 날짜는 필수입니다.");

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/service/OrdersService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/service/OrdersService.java
@@ -21,10 +21,10 @@ public class OrdersService {
     /*
      * 주문 생성
      * */
-    public Orders placeOrder(Long memberId, int quantity, BigDecimal totalPrice, Long couponMemberId, boolean couponUsed) {
+    public Orders register(Long memberId, int quantity, BigDecimal totalPrice, Long couponMemberId, boolean couponUsed, String orderKey) {
         Orders orders = null;
 
-        orders = Orders.create(memberId, quantity, totalPrice, couponMemberId, couponUsed);
+        orders = Orders.create(memberId, quantity, totalPrice, couponMemberId, couponUsed, orderKey);
         return ordersRepository.register(orders);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentContext.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentContext.java
@@ -1,0 +1,56 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.payment.CardType;
+import com.loopers.domain.payment.PaymentType;
+import com.loopers.support.error.CommonErrorType;
+import com.loopers.support.error.CoreException;
+
+import java.math.BigDecimal;
+
+public record PaymentContext(
+        String orderKey,
+        Long memberId,
+        BigDecimal amount,
+        PaymentType paymentType,
+        CardType cardType,
+        String cardNo,
+        Long paymentId
+) {
+
+    public static PaymentContext of(String orderKey,
+                                    Long memberId,
+                                    BigDecimal amount,
+                                    PaymentType paymentType,
+                                    CardType cardType,
+                                    String cardNo,
+                                    Long paymentId) {
+        if (orderKey == null || orderKey.isBlank()) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "주문 키가 비어 있습니다.");
+        }
+        if (memberId == null || memberId <= 0) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "유효하지 않은 회원 ID입니다.");
+        }
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "유효하지 않은 금액입니다.");
+        }
+        if (!PaymentType.isValid(paymentType)) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "지원하지 않는 결제 유형입니다: " + paymentType);
+        }
+        if (paymentType == PaymentType.CARD) {
+            if (!CardType.isValid(cardType)) {
+                throw new CoreException(CommonErrorType.BAD_REQUEST, "지원하지 않는 카드 유형입니다: " + cardType);
+            }
+            if (cardNo == null || cardNo.isBlank()) {
+                throw new CoreException(CommonErrorType.BAD_REQUEST, "카드 번호가 비어 있습니다.");
+            }
+            if (!cardNo.matches("\\d{4}-\\d{4}-\\d{4}-\\d{4}")) {
+                throw new CoreException(CommonErrorType.BAD_REQUEST, "카드 번호 형식이 잘못되었습니다: " + cardNo);
+            }
+        }
+        if (paymentId != null && paymentId <= 0) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "유효하지 않은 결제 ID입니다.");
+        }
+        return new PaymentContext(orderKey, memberId, amount, paymentType, cardType, cardNo, paymentId);
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentGatewayPort.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentGatewayPort.java
@@ -1,0 +1,16 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.payment.CardType;
+import com.loopers.infrastructure.payment.PgPaymentResponse;
+
+import java.math.BigDecimal;
+
+public interface PaymentGatewayPort {
+
+    PgPaymentResponse requestPayment(String orderKey,
+                                     CardType cardType,
+                                     String cardNo,
+                                     BigDecimal amount,
+                                     Long memberId);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentSchedule.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentSchedule.java
@@ -1,0 +1,19 @@
+package com.loopers.application.payment;
+
+import com.loopers.application.payment.facade.PaymentFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentSchedule {
+
+    private final PaymentFacade paymentFacade;
+
+    // 10분마다 결제 실패 건 찾아서 재고 업데이트
+    @Scheduled(fixedRate = 60 * 1000 * 10)
+    public void updatePaymentInfo() {
+        paymentFacade.searchFailedPaymentAndUpdateStock();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentSchedule.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentSchedule.java
@@ -16,4 +16,10 @@ public class PaymentSchedule {
     public void updatePaymentInfo() {
         paymentFacade.searchFailedPaymentAndUpdateStock();
     }
+
+    // 3분마다 결제 대기 건 찾아서 결제 정보 업데이트
+    @Scheduled(fixedRate = 60 * 1000 * 3)
+    public void processCallbackPayment() {
+        paymentFacade.updatePendingPayments();
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentService.java
@@ -7,6 +7,7 @@ import com.loopers.support.error.CoreException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
@@ -63,7 +64,7 @@ public class PaymentService {
         return paymentRepository.findByPendingPaymentStatus();
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void updatePaymentInfoTransactional(PgPaymentInfoResponse paymentInfo) {
         // 결제 정보 업데이트
         this.updatePaymentInfo(paymentInfo);

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentService.java
@@ -58,4 +58,8 @@ public class PaymentService {
     }
 
 
+    public List<Payment> findByPendingPaymentStatus() {
+        return paymentRepository.findByPendingPaymentStatus();
+    }
 }
+

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentService.java
@@ -1,0 +1,40 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.payment.CardType;
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentRepository;
+import com.loopers.domain.payment.PaymentType;
+import com.loopers.support.error.CommonErrorType;
+import com.loopers.support.error.CoreException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+
+    /*
+     * 결제 Entity 등록
+     * */
+    public Payment register(String orderKey,
+                            PaymentType paymentType,
+                            CardType cardType,
+                            String cardNo,
+                            BigDecimal amount) {
+
+        Payment payment = Payment.create(orderKey, paymentType, cardType, cardNo, amount);
+
+        return paymentRepository.save(payment);
+    }
+
+    public Payment findById(Long paymentId) {
+        return paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new CoreException(CommonErrorType.NOT_FOUND, "결제 정보를 찾을 수 없습니다. paymentId: " + paymentId));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentService.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 @Service
 @Slf4j
@@ -51,4 +52,10 @@ public class PaymentService {
         PaymentStatus paymentStatus = PaymentStatus.fromString(paymentInfo.data().status());
         payment.updateStatus(paymentStatus, paymentInfo.data().reason());
     }
+
+    public List<Payment> findByFailedPaymentStatus() {
+        return paymentRepository.findByFailedPaymentStatus();
+    }
+
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentService.java
@@ -7,6 +7,7 @@ import com.loopers.support.error.CoreException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -60,6 +61,12 @@ public class PaymentService {
 
     public List<Payment> findByPendingPaymentStatus() {
         return paymentRepository.findByPendingPaymentStatus();
+    }
+
+    @Transactional
+    public void updatePaymentInfoTransactional(PgPaymentInfoResponse paymentInfo) {
+        // 결제 정보 업데이트
+        this.updatePaymentInfo(paymentInfo);
     }
 }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/command/PaymentCallbackCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/command/PaymentCallbackCommand.java
@@ -1,0 +1,11 @@
+package com.loopers.application.payment.command;
+
+public record PaymentCallbackCommand(
+        String transactionKey,
+        String orderId
+) {
+
+    public static PaymentCallbackCommand of(String transactionKey, String orderId) {
+        return new PaymentCallbackCommand(transactionKey, orderId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/facade/PaymentFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/facade/PaymentFacade.java
@@ -1,12 +1,9 @@
 package com.loopers.application.payment.facade;
 
-import com.loopers.application.orderItem.service.OrderItemService;
 import com.loopers.application.payment.PaymentService;
 import com.loopers.application.payment.command.PaymentCallbackCommand;
-import com.loopers.application.stock.service.StockService;
-import com.loopers.domain.orderItem.OrderItem;
+import com.loopers.application.recovery.PaymentRecoveryService;
 import com.loopers.domain.payment.Payment;
-import com.loopers.domain.stock.Stock;
 import com.loopers.infrastructure.payment.PgPaymentApiClient;
 import com.loopers.infrastructure.payment.PgPaymentInfoResponse;
 import lombok.RequiredArgsConstructor;
@@ -23,8 +20,7 @@ public class PaymentFacade {
 
     private final PgPaymentApiClient client;
     private final PaymentService paymentService;
-    private final OrderItemService orderItemService;
-    private final StockService stockService;
+    private final PaymentRecoveryService paymentRecoveryService;
 
     @Transactional
     public void processCallbackPayment(PaymentCallbackCommand command) {
@@ -37,23 +33,17 @@ public class PaymentFacade {
         paymentService.updatePaymentInfo(paymentInfo);
     }
 
-    @Transactional
     public void searchFailedPaymentAndUpdateStock() {
-        // 결제 실패 건 전부 조회
         List<Payment> paymentList = paymentService.findByFailedPaymentStatus();
 
         for (Payment payment : paymentList) {
-            OrderItem orderItem = orderItemService.findByOrderId(payment.getOrderId());
-
-            // 재고는 업데이트를 해야하니 락을 잡아버리자.
-            Stock stock = stockService.findStockByProductIdWithLock(orderItem.getProductId());
-            stock.increaseQuantity(orderItem.getQuantity());
-
-            // payment에 재고 원복 상태 업데이트
-            payment.restoreStock();
+            try {
+                paymentRecoveryService.restoreStockForPayment(payment.getId());
+            } catch (Exception e) {
+                log.error("결제 실패 건 처리 중 오류 | paymentId={}, err={}",
+                        payment.getId(), e.toString());
+            }
         }
-
-
     }
 
     public void updatePendingPayments() {

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/facade/PaymentFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/facade/PaymentFacade.java
@@ -56,17 +56,19 @@ public class PaymentFacade {
 
     }
 
-    @Transactional
     public void updatePendingPayments() {
         // 결제 대기 건 전부 조회
         List<Payment> pendingPayments = paymentService.findByPendingPaymentStatus();
 
         for (Payment payment : pendingPayments) {
-            // 결제 정보 조회
-            PgPaymentInfoResponse paymentInfo = client.getPaymentInfo(payment.getTransactionKey(), payment.getMemberId());
+            try {
+                // 결제 정보 조회
+                PgPaymentInfoResponse paymentInfo = client.getPaymentInfo(payment.getTransactionKey(), payment.getMemberId());
 
-            // 결제 정보 업데이트
-            paymentService.updatePaymentInfo(paymentInfo);
+                paymentService.updatePaymentInfoTransactional(paymentInfo);
+            } catch (Exception e) {
+                log.error("결제 대기 건 처리 중 오류 발생 | paymentId={}, error={}", payment.getId(), e.getMessage());
+            }
         }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/facade/PaymentFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/facade/PaymentFacade.java
@@ -1,19 +1,30 @@
 package com.loopers.application.payment.facade;
 
+import com.loopers.application.orderItem.service.OrderItemService;
 import com.loopers.application.payment.PaymentService;
 import com.loopers.application.payment.command.PaymentCallbackCommand;
+import com.loopers.application.stock.service.StockService;
+import com.loopers.domain.orderItem.OrderItem;
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.stock.Stock;
 import com.loopers.infrastructure.payment.PgPaymentApiClient;
 import com.loopers.infrastructure.payment.PgPaymentInfoResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PaymentFacade {
 
     private final PgPaymentApiClient client;
     private final PaymentService paymentService;
+    private final OrderItemService orderItemService;
+    private final StockService stockService;
 
     @Transactional
     public void processCallbackPayment(PaymentCallbackCommand command) {
@@ -24,5 +35,24 @@ public class PaymentFacade {
 
         // 결제 정보 업데이트
         paymentService.updatePaymentInfo(paymentInfo);
+    }
+
+    @Transactional
+    public void searchFailedPaymentAndUpdateStock() {
+        // 결제 실패 건 전부 조회
+        List<Payment> paymentList = paymentService.findByFailedPaymentStatus();
+
+        for (Payment payment : paymentList) {
+            OrderItem orderItem = orderItemService.findByOrderId(payment.getOrderId());
+
+            // 재고는 업데이트를 해야하니 락을 잡아버리자.
+            Stock stock = stockService.findStockByProductIdWithLock(orderItem.getProductId());
+            stock.increaseQuantity(orderItem.getQuantity());
+
+            // payment에 재고 원복 상태 업데이트
+            payment.restoreStock();
+        }
+
+
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/facade/PaymentFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/facade/PaymentFacade.java
@@ -1,0 +1,28 @@
+package com.loopers.application.payment.facade;
+
+import com.loopers.application.payment.PaymentService;
+import com.loopers.application.payment.command.PaymentCallbackCommand;
+import com.loopers.infrastructure.payment.PgPaymentApiClient;
+import com.loopers.infrastructure.payment.PgPaymentInfoResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentFacade {
+
+    private final PgPaymentApiClient client;
+    private final PaymentService paymentService;
+
+    @Transactional
+    public void processCallbackPayment(PaymentCallbackCommand command) {
+        // 트랜잭션키로 사용자 ID 조회
+        Long memberId = paymentService.findMemberIdByTransactionKey(command.transactionKey());
+        // 트랜잭션키로 결제 정보 조회
+        PgPaymentInfoResponse paymentInfo = client.getPaymentInfo(command.transactionKey(), memberId);
+
+        // 결제 정보 업데이트
+        paymentService.updatePaymentInfo(paymentInfo);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/facade/PaymentFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/facade/PaymentFacade.java
@@ -55,4 +55,18 @@ public class PaymentFacade {
 
 
     }
+
+    @Transactional
+    public void updatePendingPayments() {
+        // 결제 대기 건 전부 조회
+        List<Payment> pendingPayments = paymentService.findByPendingPaymentStatus();
+
+        for (Payment payment : pendingPayments) {
+            // 결제 정보 조회
+            PgPaymentInfoResponse paymentInfo = client.getPaymentInfo(payment.getTransactionKey(), payment.getMemberId());
+
+            // 결제 정보 업데이트
+            paymentService.updatePaymentInfo(paymentInfo);
+        }
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/processor/CardPaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/processor/CardPaymentProcessor.java
@@ -1,0 +1,68 @@
+package com.loopers.application.payment.processor;
+
+import com.loopers.application.payment.PaymentContext;
+import com.loopers.application.payment.PaymentGatewayPort;
+import com.loopers.application.payment.PaymentService;
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentStatus;
+import com.loopers.domain.payment.PaymentType;
+import com.loopers.infrastructure.payment.PgPaymentResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/*
+ * 카드 결제 전략 구현체
+ * */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CardPaymentProcessor implements PaymentProcessor {
+
+    private final PaymentGatewayPort paymentGatewayPort;
+    private final PaymentService paymentService;
+
+    @Override
+    public PaymentType supports() {
+        return PaymentType.CARD;
+    }
+
+    @Override
+    public PaymentResult processPayment(PaymentContext paymentContext) {
+        PgPaymentResponse pgPaymentResponse = paymentGatewayPort.requestPayment(
+                paymentContext.orderKey(),
+                paymentContext.cardType(),
+                paymentContext.cardNo(),
+                paymentContext.amount(),
+                paymentContext.memberId()
+        );
+
+        Payment payment = paymentService.findById(paymentContext.paymentId());
+
+        // FAIL이 떨어지는 경우
+        if (pgPaymentResponse != null && !pgPaymentResponse.meta().result().equals("SUCCESS")) {
+            log.error("PG 결제 실패 | orderKey={}, memberId={}, error={}",
+                    paymentContext.orderKey(), paymentContext.memberId(), pgPaymentResponse.data().reason());
+
+            // 실패 상태 + 사유 업데이트
+            payment.updateStatus(PaymentStatus.FAILED, pgPaymentResponse.data().reason());
+
+            return PaymentResult.of(
+                    pgPaymentResponse.meta().result(),
+                    pgPaymentResponse.data().status(),
+                    pgPaymentResponse.data().reason(),
+                    null
+            );
+        }
+
+        // 페이먼트 트랜잭션키 업데이트
+        payment.updateTransactionKey(pgPaymentResponse.data().transactionKey());
+
+        return PaymentResult.of(
+                pgPaymentResponse.meta().result(),
+                pgPaymentResponse.data().status(),
+                pgPaymentResponse.data().reason(),
+                pgPaymentResponse.data().transactionKey()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/processor/CardPaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/processor/CardPaymentProcessor.java
@@ -41,11 +41,11 @@ public class CardPaymentProcessor implements PaymentProcessor {
 
         // FAIL이 떨어지는 경우
         if (pgPaymentResponse != null && !pgPaymentResponse.meta().result().equals("SUCCESS")) {
-            log.error("PG 결제 실패 | orderKey={}, memberId={}, error={}",
-                    paymentContext.orderKey(), paymentContext.memberId(), pgPaymentResponse.data().reason());
+            log.error("PG 결제 실패 | orderKey={}, memberId={}, error={}, message={}",
+                    paymentContext.orderKey(), paymentContext.memberId(), pgPaymentResponse.data().reason(), pgPaymentResponse.meta().message());
 
             // 실패 상태 + 사유 업데이트
-            payment.updateStatus(PaymentStatus.FAILED, pgPaymentResponse.data().reason());
+            payment.updateStatus(PaymentStatus.FAILED, pgPaymentResponse.meta().message());
 
             return PaymentResult.of(
                     pgPaymentResponse.meta().result(),

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/processor/PaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/processor/PaymentProcessor.java
@@ -1,0 +1,15 @@
+package com.loopers.application.payment.processor;
+
+import com.loopers.application.payment.PaymentContext;
+import com.loopers.domain.payment.PaymentType;
+
+/*
+ * 결제 타입을 결정하기 위한 전략 인터페이스
+ * */
+public interface PaymentProcessor {
+
+    PaymentType supports();
+
+    PaymentResult processPayment(PaymentContext paymentContext);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/processor/PaymentProcessorRegistry.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/processor/PaymentProcessorRegistry.java
@@ -1,0 +1,25 @@
+package com.loopers.application.payment.processor;
+
+import com.loopers.domain.payment.PaymentType;
+import com.loopers.support.error.CommonErrorType;
+import com.loopers.support.error.CoreException;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Component
+public class PaymentProcessorRegistry {
+    private final Map<PaymentType, PaymentProcessor> map;
+
+    public PaymentProcessorRegistry(List<PaymentProcessor> processors) {
+        this.map = processors.stream().collect(Collectors.toMap(PaymentProcessor::supports, p -> p));
+    }
+
+    public PaymentProcessor get(PaymentType type) {
+        return Optional.ofNullable(map.get(type))
+                .orElseThrow(() -> new CoreException(CommonErrorType.BAD_REQUEST, "지원하지 않는 결제 타입입니다: " + type));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/processor/PaymentResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/processor/PaymentResult.java
@@ -1,0 +1,14 @@
+package com.loopers.application.payment.processor;
+
+public record PaymentResult
+        (
+                String result,
+                String status,
+                String reason,
+                String transactionKey
+        ) {
+
+    public static PaymentResult of(String result, String status, String reason, String transactionKey) {
+        return new PaymentResult(result, status, reason, transactionKey);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/processor/PointPaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/processor/PointPaymentProcessor.java
@@ -32,13 +32,11 @@ public class PointPaymentProcessor implements PaymentProcessor {
         // 포인트 사용
         point.use(paymentContext.amount());
 
-        // 결제 데이터 생성
-        paymentService.register(
-                paymentContext.orderKey(),
-                PaymentType.POINT,
-                null, // 포인트 결제는 카드 타입이 없음
-                null, // 포인트 결제는 카드 번호가 없음
-                paymentContext.amount()
+        return PaymentResult.of(
+                "SUCCESS",
+                "COMPLETED",
+                null,
+                null
         );
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/processor/PointPaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/processor/PointPaymentProcessor.java
@@ -1,0 +1,44 @@
+package com.loopers.application.payment.processor;
+
+import com.loopers.application.payment.PaymentContext;
+import com.loopers.application.payment.PaymentService;
+import com.loopers.application.point.service.PointService;
+import com.loopers.domain.payment.PaymentType;
+import com.loopers.domain.point.Point;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/*
+ * 포인트 결제 전략 구현체
+ * */
+@Component
+@RequiredArgsConstructor
+public class PointPaymentProcessor implements PaymentProcessor {
+
+    private final PointService pointService;
+    private final PaymentService paymentService;
+
+
+    @Override
+    public PaymentType supports() {
+        return PaymentType.POINT;
+    }
+
+    @Override
+    public PaymentResult processPayment(PaymentContext paymentContext) {
+        // 포인트 확인
+        Point point = pointService.getPointByMemberIdWithLock(paymentContext.memberId());
+        point.enoughPoint(paymentContext.amount());
+        // 포인트 사용
+        point.use(paymentContext.amount());
+
+        // 결제 데이터 생성
+        paymentService.register(
+                paymentContext.orderKey(),
+                PaymentType.POINT,
+                null, // 포인트 결제는 카드 타입이 없음
+                null, // 포인트 결제는 카드 번호가 없음
+                paymentContext.amount()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/service/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/service/PointService.java
@@ -2,6 +2,8 @@ package com.loopers.application.point.service;
 
 import com.loopers.domain.point.Point;
 import com.loopers.domain.point.PointRepository;
+import com.loopers.support.error.CommonErrorType;
+import com.loopers.support.error.CoreException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,11 +14,13 @@ public class PointService {
     private final PointRepository pointRepository;
 
     public Point getPointByMemberIdWithLock(Long memberId) {
-        return pointRepository.findByMemberIdWithLock(memberId);
+        return pointRepository.findByMemberIdWithLock(memberId)
+                .orElseThrow(() -> new CoreException(CommonErrorType.NOT_FOUND, "사용자의 포인트를 찾을 수 없습니다. memberId: " + memberId));
     }
 
     public Point getPointByMemberId(Long memberId) {
-        return pointRepository.findByMemberId(memberId);
+        return pointRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new CoreException(CommonErrorType.NOT_FOUND, "사용자의 포인트를 찾을 수 없습니다. memberId: " + memberId));
     }
 
     public void register(Long id) {

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/facade/ProductFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/facade/ProductFacade.java
@@ -7,6 +7,7 @@ import com.loopers.application.product.result.ProductListResult;
 import com.loopers.application.product.result.ProductRegisterResult;
 import com.loopers.application.product.service.ProductService;
 import com.loopers.application.productlike.service.ProductLikeService;
+import com.loopers.application.stock.service.StockService;
 import com.loopers.domain.brand.Brand;
 import com.loopers.domain.product.Product;
 import com.loopers.interfaces.api.product.dto.ProductRegisterReqDTO;
@@ -25,6 +26,7 @@ import java.util.List;
 public class ProductFacade {
 
     private final ProductService productService;
+    private final StockService stockService;
     private final BrandService brandService;
     private final ProductLikeService productLikeService;
 
@@ -60,6 +62,9 @@ public class ProductFacade {
      * */
     @Transactional
     public ProductRegisterResult registerProduct(ProductRegisterReqDTO reqDTO) {
-        return productService.registerProduct(reqDTO);
+        ProductRegisterResult productRegisterResult = productService.registerProduct(reqDTO);
+        stockService.registerStock(productRegisterResult.productId(), reqDTO.stock());
+
+        return productRegisterResult;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/product/service/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/product/service/ProductService.java
@@ -15,7 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -92,7 +91,6 @@ public class ProductService {
         return products.stream().map(ProductListResult::of).toList();
     }
 
-    @Transactional
     public ProductRegisterResult registerProduct(ProductRegisterReqDTO reqDTO) {
         if (reqDTO == null) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "상품 등록 요청이 유효하지 않습니다.");

--- a/apps/commerce-api/src/main/java/com/loopers/application/productlike/ProductLikeSchedule.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/productlike/ProductLikeSchedule.java
@@ -1,4 +1,4 @@
-package com.loopers.infrastructure.productlike;
+package com.loopers.application.productlike;
 
 import com.loopers.application.productlike.facade.ProductLikeFacade;
 import lombok.RequiredArgsConstructor;

--- a/apps/commerce-api/src/main/java/com/loopers/application/recovery/PaymentRecoveryService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/recovery/PaymentRecoveryService.java
@@ -1,0 +1,33 @@
+package com.loopers.application.recovery;
+
+import com.loopers.application.orderItem.service.OrderItemService;
+import com.loopers.application.payment.PaymentService;
+import com.loopers.application.stock.service.StockService;
+import com.loopers.domain.orderItem.OrderItem;
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.stock.Stock;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentRecoveryService {
+    private final PaymentService paymentService;
+    private final OrderItemService orderItemService;
+    private final StockService stockService;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void restoreStockForPayment(Long paymentId) {
+        Payment payment = paymentService.findById(paymentId);
+
+        OrderItem orderItem = orderItemService.findByOrderId(payment.getOrderId());
+
+        // 락을 잡은 상태로 재고 가져옴.
+        Stock stock = stockService.findStockByProductIdWithLock(orderItem.getProductId());
+
+        stock.increaseQuantity(orderItem.getQuantity());
+        payment.restoreStock();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/stock/service/StockService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/stock/service/StockService.java
@@ -21,4 +21,8 @@ public class StockService {
         Stock stock = Stock.create(productId, stockQuantity);
         stockRepository.register(stock);
     }
+
+    public Stock findStockByProductIdWithLock(Long productId) {
+        return stockRepository.findByProductIdWithLock(productId);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/stock/service/StockService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/stock/service/StockService.java
@@ -16,4 +16,9 @@ public class StockService {
     public Stock findStockByProductId(Long productId) {
         return stockRepository.findByProductIdWithLock(productId);
     }
+
+    public void registerStock(Long productId, int stockQuantity) {
+        Stock stock = Stock.create(productId, stockQuantity);
+        stockRepository.register(stock);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/config/RestTemplateConfig.java
+++ b/apps/commerce-api/src/main/java/com/loopers/config/RestTemplateConfig.java
@@ -2,6 +2,7 @@ package com.loopers.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -9,7 +10,10 @@ public class RestTemplateConfig {
 
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
+        factory.setConnectTimeout(300);
+        factory.setReadTimeout(1500);
+        return new RestTemplate(factory);
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/config/RestTemplateConfig.java
+++ b/apps/commerce-api/src/main/java/com/loopers/config/RestTemplateConfig.java
@@ -1,0 +1,15 @@
+package com.loopers.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/brand/BrandRepository.java
@@ -1,14 +1,11 @@
 package com.loopers.domain.brand;
 
-import org.springframework.stereotype.Repository;
-
 import java.util.List;
 import java.util.Optional;
 
 /**
  * BrandModel에서 사용하는 DB 로직 추상 메서드를 정의합니다.
  */
-@Repository
 public interface BrandRepository {
 
     /**

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
@@ -1,11 +1,12 @@
 package com.loopers.domain.coupon;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CouponRepository {
     List<Coupon> findAllByIds(List<Long> couponIds);
 
     Coupon save(Coupon coupon);
 
-    Coupon findById(Long couponId);
+    Optional<Coupon> findById(Long couponId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/couponmember/CouponMemberRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/couponmember/CouponMemberRepository.java
@@ -1,6 +1,7 @@
 package com.loopers.domain.couponmember;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CouponMemberRepository {
 
@@ -8,5 +9,5 @@ public interface CouponMemberRepository {
 
     CouponMember save(CouponMember couponMember);
 
-    CouponMember findByCouponIdAndMemberId(Long couponId, Long memberId);
+    Optional<CouponMember> findByCouponIdAndMemberId(Long couponId, Long memberId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberRepository.java
@@ -10,5 +10,4 @@ public interface MemberRepository {
     Optional<Member> register(Member member);
 
     Optional<Member> findById(Long memberId);
-
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/member/MemberRepository.java
@@ -1,13 +1,10 @@
 package com.loopers.domain.member;
 
-import org.springframework.stereotype.Repository;
-
 import java.util.Optional;
 
 /**
  * MemberModel에서 사용하는 DB 로직 추상 메서드를 정의합니다.
  */
-@Repository
 public interface MemberRepository {
 
     Optional<Member> register(Member member);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orderItem/OrderItemRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orderItem/OrderItemRepository.java
@@ -1,7 +1,10 @@
 package com.loopers.domain.orderItem;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface OrderItemRepository {
     void saveAll(List<OrderItem> orderItems);
+
+    Optional<OrderItem> findByOrdersId(Long ordersId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/Orders.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/Orders.java
@@ -28,18 +28,22 @@ public class Orders extends BaseEntity {
     @Column(nullable = true)
     private Long couponMemberId;
 
+    @Column(nullable = false)
+    private String orderKey;
+
     protected Orders() {
     }
 
-    private Orders(Long memberId, int quantity, BigDecimal totalPrice, Long couponMemberId) {
+    private Orders(Long memberId, int quantity, BigDecimal totalPrice, Long couponMemberId, String orderKey) {
         this.memberId = memberId;
         this.orderStatus = OrderStatus.PENDING;
         this.quantity = quantity;
         this.totalPrice = totalPrice;
         this.couponMemberId = couponMemberId;
+        this.orderKey = orderKey;
     }
 
-    public static Orders create(Long memberId, int quantity, BigDecimal totalPrice, Long couponMemberId, boolean couponUsed) {
+    public static Orders create(Long memberId, int quantity, BigDecimal totalPrice, Long couponMemberId, boolean couponUsed, String orderKey) {
         if (memberId == null || memberId <= 0) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 회원 ID가 필요합니다.");
         }
@@ -52,8 +56,11 @@ public class Orders extends BaseEntity {
         if (couponUsed && (couponMemberId == null || couponMemberId <= 0)) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "쿠폰 사용 시 유효한 쿠폰 회원 ID가 필요합니다.");
         }
+        if (orderKey == null || orderKey.isBlank()) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 주문 키가 필요합니다.");
+        }
 
-        return new Orders(memberId, quantity, totalPrice, couponMemberId);
+        return new Orders(memberId, quantity, totalPrice, couponMemberId, orderKey);
     }
 
     public Long getMemberId() {
@@ -74,5 +81,9 @@ public class Orders extends BaseEntity {
 
     public Long getCouponMemberId() {
         return couponMemberId;
+    }
+
+    public String getOrderKey() {
+        return orderKey;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/CardType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/CardType.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.payment;
+
+public enum CardType {
+    SAMSUNG, KB, HYUNDAI;
+
+    public static boolean isValid(CardType cardType) {
+        return cardType == SAMSUNG || cardType == KB || cardType == HYUNDAI;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
@@ -1,0 +1,127 @@
+package com.loopers.domain.payment;
+
+import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CommonErrorType;
+import com.loopers.support.error.CoreException;
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "payment")
+public class Payment extends BaseEntity {
+
+    @Column(nullable = true)
+    private String transactionKey;
+
+    @Column(nullable = false)
+    private String orderId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PaymentType paymentType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = true)
+    private CardType cardType;
+
+    @Column(nullable = true)
+    private String cardNo;
+
+    @Column(nullable = false)
+    private BigDecimal amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PaymentStatus status;
+
+    @Column(nullable = true, length = 500)
+    private String reason;
+
+    protected Payment() {
+    }
+
+    private Payment(String orderId, PaymentType paymentType, CardType cardType, String cardNo, BigDecimal amount) {
+        this.orderId = orderId;
+        this.paymentType = paymentType;
+        this.cardType = cardType;
+        this.cardNo = cardNo;
+        this.amount = amount;
+        this.status = PaymentStatus.PENDING;
+    }
+
+    public static Payment create(String orderId, PaymentType paymentType, CardType cardType, String cardNo, BigDecimal amount) {
+        isValid(orderId, paymentType, cardType, cardNo, amount);
+
+        return new Payment(orderId, paymentType, cardType, cardNo, amount);
+    }
+
+    public static void isValid(String orderId, PaymentType paymentType, CardType cardType, String cardNo, BigDecimal amount) {
+        if (orderId == null || orderId.isBlank()) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 주문 ID가 필요합니다.");
+        }
+        if (paymentType == null || !PaymentType.isValid(paymentType)) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 결제 유형이 필요합니다.");
+        }
+        if (cardType == null || !CardType.isValid(cardType)) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 카드 유형이 필요합니다.");
+        }
+        if (cardNo == null || cardNo.isBlank()) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 카드 번호가 필요합니다.");
+        }
+        if (!cardNo.matches("\\d{4}-\\d{4}-\\d{4}-\\d{4}")) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "카드 번호는 xxxx-xxxx-xxxx-xxxx 형식이어야 합니다.");
+        }
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 금액이 필요합니다.");
+        }
+
+    }
+
+    public String getTransactionKey() {
+        return transactionKey;
+    }
+
+    public String getOrderId() {
+        return orderId;
+    }
+
+    public PaymentType getPaymentType() {
+        return paymentType;
+    }
+
+    public CardType getCardType() {
+        return cardType;
+    }
+
+    public String getCardNo() {
+        return cardNo;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public PaymentStatus getStatus() {
+        return status;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void updateTransactionKey(String transactionKey) {
+        if (transactionKey == null || transactionKey.isBlank()) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 트랜잭션 키가 필요합니다.");
+        }
+        this.transactionKey = transactionKey;
+    }
+
+    public void updateStatus(PaymentStatus status, String reason) {
+        if (status == null || !PaymentStatus.isValid(status)) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 결제 상태가 필요합니다.");
+        }
+        this.status = status;
+        this.reason = reason;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
@@ -15,7 +15,10 @@ public class Payment extends BaseEntity {
     private String transactionKey;
 
     @Column(nullable = false)
-    private String orderId;
+    private Long orderId;
+
+    @Column(nullable = false)
+    private String orderKey;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -24,6 +27,9 @@ public class Payment extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = true)
     private CardType cardType;
+
+    @Column(nullable = false)
+    private Long memberId;
 
     @Column(nullable = true)
     private String cardNo;
@@ -41,24 +47,29 @@ public class Payment extends BaseEntity {
     protected Payment() {
     }
 
-    private Payment(String orderId, PaymentType paymentType, CardType cardType, String cardNo, BigDecimal amount) {
+    private Payment(Long orderId, String orderKey, PaymentType paymentType, CardType cardType, String cardNo, BigDecimal amount, Long memberId) {
         this.orderId = orderId;
+        this.orderKey = orderKey;
         this.paymentType = paymentType;
         this.cardType = cardType;
         this.cardNo = cardNo;
         this.amount = amount;
         this.status = PaymentStatus.PENDING;
+        this.memberId = memberId;
     }
 
-    public static Payment create(String orderId, PaymentType paymentType, CardType cardType, String cardNo, BigDecimal amount) {
-        isValid(orderId, paymentType, cardType, cardNo, amount);
+    public static Payment create(Long orderId, String orderKey, PaymentType paymentType, CardType cardType, String cardNo, BigDecimal amount, Long memberId) {
+        isValid(orderId, orderKey, paymentType, cardType, cardNo, amount, memberId);
 
-        return new Payment(orderId, paymentType, cardType, cardNo, amount);
+        return new Payment(orderId, orderKey, paymentType, cardType, cardNo, amount, memberId);
     }
 
-    public static void isValid(String orderId, PaymentType paymentType, CardType cardType, String cardNo, BigDecimal amount) {
-        if (orderId == null || orderId.isBlank()) {
+    public static void isValid(Long orderId, String orderKey, PaymentType paymentType, CardType cardType, String cardNo, BigDecimal amount, Long memberId) {
+        if (orderId == null || orderId <= 0) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 주문 ID가 필요합니다.");
+        }
+        if (orderKey == null || orderKey.isBlank()) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 주문 키가 필요합니다.");
         }
         if (paymentType == null || !PaymentType.isValid(paymentType)) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 결제 유형이 필요합니다.");
@@ -75,6 +86,9 @@ public class Payment extends BaseEntity {
         if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 금액이 필요합니다.");
         }
+        if (memberId == null || memberId <= 0) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 회원 ID가 필요합니다.");
+        }
 
     }
 
@@ -82,8 +96,12 @@ public class Payment extends BaseEntity {
         return transactionKey;
     }
 
-    public String getOrderId() {
+    public Long getOrderId() {
         return orderId;
+    }
+
+    public String getOrderKey() {
+        return orderKey;
     }
 
     public PaymentType getPaymentType() {
@@ -108,6 +126,10 @@ public class Payment extends BaseEntity {
 
     public String getReason() {
         return reason;
+    }
+
+    public Long getMemberId() {
+        return memberId;
     }
 
     public void updateTransactionKey(String transactionKey) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
@@ -78,14 +78,16 @@ public class Payment extends BaseEntity {
         if (paymentType == null || !PaymentType.isValid(paymentType)) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 결제 유형이 필요합니다.");
         }
-        if (cardType == null || !CardType.isValid(cardType)) {
-            throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 카드 유형이 필요합니다.");
-        }
-        if (cardNo == null || cardNo.isBlank()) {
-            throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 카드 번호가 필요합니다.");
-        }
-        if (!cardNo.matches("\\d{4}-\\d{4}-\\d{4}-\\d{4}")) {
-            throw new CoreException(CommonErrorType.BAD_REQUEST, "카드 번호는 xxxx-xxxx-xxxx-xxxx 형식이어야 합니다.");
+        if (paymentType == PaymentType.CARD) {
+            if (cardType == null || !CardType.isValid(cardType)) {
+                throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 카드 유형이 필요합니다.");
+            }
+            if (cardNo == null || cardNo.isBlank()) {
+                throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 카드 번호가 필요합니다.");
+            }
+            if (!cardNo.matches("\\d{4}-\\d{4}-\\d{4}-\\d{4}")) {
+                throw new CoreException(CommonErrorType.BAD_REQUEST, "카드 번호는 xxxx-xxxx-xxxx-xxxx 형식이어야 합니다.");
+            }
         }
         if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 금액이 필요합니다.");

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
@@ -44,6 +44,9 @@ public class Payment extends BaseEntity {
     @Column(nullable = true, length = 500)
     private String reason;
 
+    @Column(nullable = false)
+    private boolean restoredStatus;
+
     protected Payment() {
     }
 
@@ -56,6 +59,7 @@ public class Payment extends BaseEntity {
         this.amount = amount;
         this.status = PaymentStatus.PENDING;
         this.memberId = memberId;
+        this.restoredStatus = false;
     }
 
     public static Payment create(Long orderId, String orderKey, PaymentType paymentType, CardType cardType, String cardNo, BigDecimal amount, Long memberId) {
@@ -132,6 +136,10 @@ public class Payment extends BaseEntity {
         return memberId;
     }
 
+    public boolean isRestoredStatus() {
+        return restoredStatus;
+    }
+
     public void updateTransactionKey(String transactionKey) {
         if (transactionKey == null || transactionKey.isBlank()) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 트랜잭션 키가 필요합니다.");
@@ -145,5 +153,12 @@ public class Payment extends BaseEntity {
         }
         this.status = status;
         this.reason = reason;
+    }
+
+    public void restoreStock() {
+        if (this.restoredStatus) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "이미 재고가 복원되었습니다.");
+        }
+        this.restoredStatus = true;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.domain.payment;
+
+import java.util.Optional;
+
+public interface PaymentRepository {
+    Payment save(Payment payment);
+
+    Optional<Payment> findById(Long paymentId);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
@@ -1,5 +1,6 @@
 package com.loopers.domain.payment;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PaymentRepository {
@@ -10,4 +11,6 @@ public interface PaymentRepository {
     Optional<Long> findMemberIdByTransactionKey(String transactionKey);
 
     Optional<Payment> findByTransactionKey(String transactionKey);
+
+    List<Payment> findByFailedPaymentStatus();
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
@@ -7,4 +7,7 @@ public interface PaymentRepository {
 
     Optional<Payment> findById(Long paymentId);
 
+    Optional<Long> findMemberIdByTransactionKey(String transactionKey);
+
+    Optional<Payment> findByTransactionKey(String transactionKey);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
@@ -13,4 +13,6 @@ public interface PaymentRepository {
     Optional<Payment> findByTransactionKey(String transactionKey);
 
     List<Payment> findByFailedPaymentStatus();
+
+    List<Payment> findByPendingPaymentStatus();
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentStatus.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentStatus.java
@@ -1,0 +1,12 @@
+package com.loopers.domain.payment;
+
+public enum PaymentStatus {
+    SUCCESS,
+    FAILED,
+    PENDING,
+    CANCELLED;
+
+    public static boolean isValid(PaymentStatus paymentStatus) {
+        return paymentStatus == SUCCESS || paymentStatus == FAILED || paymentStatus == PENDING || paymentStatus == CANCELLED;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentStatus.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentStatus.java
@@ -1,5 +1,8 @@
 package com.loopers.domain.payment;
 
+import com.loopers.support.error.CommonErrorType;
+import com.loopers.support.error.CoreException;
+
 public enum PaymentStatus {
     SUCCESS,
     FAILED,
@@ -8,5 +11,13 @@ public enum PaymentStatus {
 
     public static boolean isValid(PaymentStatus paymentStatus) {
         return paymentStatus == SUCCESS || paymentStatus == FAILED || paymentStatus == PENDING || paymentStatus == CANCELLED;
+    }
+
+    public static PaymentStatus fromString(String status) {
+        try {
+            return PaymentStatus.valueOf(status.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "지원하지 않는 결제 상태입니다: " + status);
+        }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentType.java
@@ -1,0 +1,9 @@
+package com.loopers.domain.payment;
+
+public enum PaymentType {
+    CARD, POINT;
+
+    public static boolean isValid(PaymentType paymentType) {
+        return paymentType == CARD || paymentType == POINT;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
@@ -1,12 +1,14 @@
 package com.loopers.domain.point;
 
+import java.util.Optional;
+
 public interface PointRepository {
 
-    Point findByMemberIdWithLock(Long memberId);
+    Optional<Point> findByMemberIdWithLock(Long memberId);
 
-    Point findByMemberId(Long memberId);
+    Optional<Point> findByMemberId(Long memberId);
 
     Point register(Point point);
 
-    Point findById(Long id);
+    Optional<Point> findById(Long id);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -1,7 +1,6 @@
 package com.loopers.domain.product;
 
 import com.loopers.support.sort.ProductSortType;
-import org.springframework.stereotype.Repository;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -10,7 +9,6 @@ import java.util.Optional;
 /**
  * ProductModel에서 사용하는 DB 로직 추상 메서드를 정의합니다.
  */
-@Repository
 public interface ProductRepository {
 
     Optional<Product> findById(Long productId);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/productlike/ProductLikeRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/productlike/ProductLikeRepository.java
@@ -1,7 +1,6 @@
 package com.loopers.domain.productlike;
 
 import com.loopers.application.productlike.query.ProductLikeGroup;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,7 +8,6 @@ import java.util.Optional;
 /**
  * LikeModel에서 사용하는 DB 로직 추상 메서드를 정의합니다.
  */
-@Repository
 public interface ProductLikeRepository {
 
     boolean existsByProductIdAndMemberId(Long productId, Long memberId);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/stock/Stock.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/stock/Stock.java
@@ -53,6 +53,13 @@ public class Stock extends BaseEntity {
         this.quantity -= quantity;
     }
 
+    public void increaseQuantity(int quantity) {
+        if (quantity <= 0) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "증가할 수량은 1 이상이어야 합니다.");
+        }
+        this.quantity += quantity;
+    }
+
     public void enoughQuantity(int quantity) {
         if (quantity <= 0) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "확인할 수량은 1 이상이어야 합니다.");

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CounponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CounponRepositoryImpl.java
@@ -2,12 +2,11 @@ package com.loopers.infrastructure.coupon;
 
 import com.loopers.domain.coupon.Coupon;
 import com.loopers.domain.coupon.CouponRepository;
-import com.loopers.support.error.CommonErrorType;
-import com.loopers.support.error.CoreException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -26,8 +25,7 @@ public class CounponRepositoryImpl implements CouponRepository {
     }
 
     @Override
-    public Coupon findById(Long couponId) {
-        return couponJpaRepository.findById(couponId)
-                .orElseThrow(() -> new CoreException(CommonErrorType.BAD_REQUEST, "쿠폰을 찾을 수 없습니다. 쿠폰 ID: " + couponId));
+    public Optional<Coupon> findById(Long couponId) {
+        return couponJpaRepository.findById(couponId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/couponmember/CounponMemberRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/couponmember/CounponMemberRepositoryImpl.java
@@ -2,12 +2,11 @@ package com.loopers.infrastructure.couponmember;
 
 import com.loopers.domain.couponmember.CouponMember;
 import com.loopers.domain.couponmember.CouponMemberRepository;
-import com.loopers.support.error.CommonErrorType;
-import com.loopers.support.error.CoreException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -26,8 +25,7 @@ public class CounponMemberRepositoryImpl implements CouponMemberRepository {
     }
 
     @Override
-    public CouponMember findByCouponIdAndMemberId(Long couponId, Long memberId) {
-        return couponMemberJpaRepository.findByCouponIdAndMemberIdIsActive(couponId, memberId)
-                .orElseThrow(() -> new CoreException(CommonErrorType.BAD_REQUEST, "쿠폰을 찾을 수 없습니다. couponId: " + couponId + ", memberId: " + memberId));
+    public Optional<CouponMember> findByCouponIdAndMemberId(Long couponId, Long memberId) {
+        return couponMemberJpaRepository.findByCouponIdAndMemberIdIsActive(couponId, memberId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/orderItem/OrderItemJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/orderItem/OrderItemJpaRepository.java
@@ -2,7 +2,12 @@ package com.loopers.infrastructure.orderItem;
 
 import com.loopers.domain.orderItem.OrderItem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface OrderItemJpaRepository extends JpaRepository<OrderItem, Long> {
 
+    @Query("SELECT oi FROM OrderItem oi WHERE oi.ordersId = :ordersId")
+    Optional<OrderItem> findByOrdersId(Long ordersId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/orderItem/OrderItemRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/orderItem/OrderItemRepositoryImpl.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -18,5 +19,10 @@ public class OrderItemRepositoryImpl implements OrderItemRepository {
     @Override
     public void saveAll(List<OrderItem> orderItems) {
         orderItemJpaRepository.saveAll(orderItems);
+    }
+
+    @Override
+    public Optional<OrderItem> findByOrdersId(Long orderId) {
+        return orderItemJpaRepository.findByOrdersId(orderId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentGatewayRestPort.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentGatewayRestPort.java
@@ -1,0 +1,66 @@
+package com.loopers.infrastructure.payment;
+
+import com.loopers.application.payment.PaymentGatewayPort;
+import com.loopers.domain.payment.CardType;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentGatewayRestPort implements PaymentGatewayPort {
+
+    private final RestTemplate restTemplate;
+
+    private static final String PAYMENT_API_URL = "http://localhost:8082/api/v1/payments";
+
+    @Retry(name = "pg-api", fallbackMethod = "paymentFallback")
+    @CircuitBreaker(name = "pg-api")
+    public PgPaymentResponse requestPayment(String orderKey,
+                                            CardType cardType,
+                                            String cardNo,
+                                            BigDecimal amount,
+                                            Long memberId) {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("X-USER-ID", String.valueOf(memberId));
+
+        HttpEntity<PaymentRequest> httpEntity =
+                new HttpEntity<>(PaymentRequest.of(orderKey, cardType, cardNo, amount), headers);
+
+        // 실제 결제 API 호출
+        ResponseEntity<PgPaymentResponse> response = restTemplate.
+                exchange(PAYMENT_API_URL, HttpMethod.POST, httpEntity, new ParameterizedTypeReference<>() {
+                });
+
+
+        return response.getBody();
+    }
+
+    private PgPaymentResponse paymentFallback(String orderKey, CardType cardType, String cardNo, BigDecimal amount,
+                                              Long memberId, Throwable t) {
+        if (t instanceof io.github.resilience4j.circuitbreaker.CallNotPermittedException) {
+            log.error("서킷 브레이커 발동: {}", t.getMessage());
+            return new PgPaymentResponse(
+                    new PgPaymentResponse.Meta("FAIL", "TIMEOUT", "PG 호출이 지연되었습니다.(서킷브레이커 발동)"),
+                    new PgPaymentResponse.Data(null, "CIRCUIT_BREAKER_OPEN", t.getMessage())
+            );
+        } else {
+            log.error("PG 호출 실패: {}", t.getMessage());
+            return new PgPaymentResponse(
+                    new PgPaymentResponse.Meta("FAIL", "RETRY_FAIL", "PG 호출이 실패했습니다.(재시도 실패)"),
+                    new PgPaymentResponse.Data(null, "RETRY_FAIL", t.getMessage())
+            );
+        }
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentGatewayRestPort.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentGatewayRestPort.java
@@ -42,20 +42,19 @@ public class PaymentGatewayRestPort implements PaymentGatewayPort {
                 exchange(PAYMENT_API_URL, HttpMethod.POST, httpEntity, new ParameterizedTypeReference<>() {
                 });
 
-
         return response.getBody();
     }
 
     private PgPaymentResponse paymentFallback(String orderKey, CardType cardType, String cardNo, BigDecimal amount,
                                               Long memberId, Throwable t) {
         if (t instanceof io.github.resilience4j.circuitbreaker.CallNotPermittedException) {
-            log.error("서킷 브레이커 발동: {}", t.getMessage());
+            log.error("CurcuitBreaker 열림 : {}", t.getMessage());
             return new PgPaymentResponse(
                     new PgPaymentResponse.Meta("FAIL", "TIMEOUT", "PG 호출이 지연되었습니다.(서킷브레이커 발동)"),
                     new PgPaymentResponse.Data(null, "CIRCUIT_BREAKER_OPEN", t.getMessage())
             );
         } else {
-            log.error("PG 호출 실패: {}", t.getMessage());
+            log.error("Retry 시도 : {}", t.getMessage());
             return new PgPaymentResponse(
                     new PgPaymentResponse.Meta("FAIL", "RETRY_FAIL", "PG 호출이 실패했습니다.(재시도 실패)"),
                     new PgPaymentResponse.Data(null, "RETRY_FAIL", t.getMessage())

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.payment;
+
+import com.loopers.domain.payment.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentJpaRepository extends JpaRepository<Payment, Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
@@ -2,6 +2,15 @@ package com.loopers.infrastructure.payment;
 
 import com.loopers.domain.payment.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface PaymentJpaRepository extends JpaRepository<Payment, Long> {
+
+    @Query("SELECT p.memberId FROM Payment p WHERE p.transactionKey = :transactionKey")
+    Optional<Long> findMemberIdByTransactionKey(String transactionKey);
+
+    @Query("SELECT p FROM Payment p WHERE p.transactionKey = :transactionKey")
+    Optional<Payment> findByTransactionKey(String transactionKey);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
@@ -4,6 +4,7 @@ import com.loopers.domain.payment.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PaymentJpaRepository extends JpaRepository<Payment, Long> {
@@ -13,4 +14,7 @@ public interface PaymentJpaRepository extends JpaRepository<Payment, Long> {
 
     @Query("SELECT p FROM Payment p WHERE p.transactionKey = :transactionKey")
     Optional<Payment> findByTransactionKey(String transactionKey);
+
+    @Query("SELECT p FROM Payment p WHERE p.status = 'FAILED' and p.restoredStatus = false ")
+    List<Payment> findByFailedPaymentStatus();
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
@@ -17,4 +17,7 @@ public interface PaymentJpaRepository extends JpaRepository<Payment, Long> {
 
     @Query("SELECT p FROM Payment p WHERE p.status = 'FAILED' and p.restoredStatus = false ")
     List<Payment> findByFailedPaymentStatus();
+
+    @Query("SELECT p FROM Payment p WHERE p.status = 'PENDING'")
+    List<Payment> findByPendingPaymentStatus();
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
@@ -22,4 +22,14 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     public Optional<Payment> findById(Long paymentId) {
         return paymentJpaRepository.findById(paymentId);
     }
+
+    @Override
+    public Optional<Long> findMemberIdByTransactionKey(String transactionKey) {
+        return paymentJpaRepository.findMemberIdByTransactionKey(transactionKey);
+    }
+
+    @Override
+    public Optional<Payment> findByTransactionKey(String transactionKey) {
+        return paymentJpaRepository.findByTransactionKey(transactionKey);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.loopers.infrastructure.payment;
+
+import com.loopers.domain.payment.Payment;
+import com.loopers.domain.payment.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentRepositoryImpl implements PaymentRepository {
+
+    private final PaymentJpaRepository paymentJpaRepository;
+
+    @Override
+    public Payment save(Payment payment) {
+        return paymentJpaRepository.save(payment);
+    }
+
+    @Override
+    public Optional<Payment> findById(Long paymentId) {
+        return paymentJpaRepository.findById(paymentId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.loopers.domain.payment.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -31,5 +32,10 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     @Override
     public Optional<Payment> findByTransactionKey(String transactionKey) {
         return paymentJpaRepository.findByTransactionKey(transactionKey);
+    }
+
+    @Override
+    public List<Payment> findByFailedPaymentStatus() {
+        return paymentJpaRepository.findByFailedPaymentStatus();
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
@@ -38,4 +38,9 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     public List<Payment> findByFailedPaymentStatus() {
         return paymentJpaRepository.findByFailedPaymentStatus();
     }
+
+    @Override
+    public List<Payment> findByPendingPaymentStatus() {
+        return paymentJpaRepository.findByPendingPaymentStatus();
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRequest.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRequest.java
@@ -1,0 +1,20 @@
+package com.loopers.infrastructure.payment;
+
+import com.loopers.domain.payment.CardType;
+
+import java.math.BigDecimal;
+
+public record PaymentRequest(
+        String orderId,
+        CardType cardType,
+        String cardNo,
+        String amount,
+        String callbackUrl
+) {
+
+    private static final String CALLBACK_URL = "http://localhost:8080/api/v1/orders/callback";
+
+    public static PaymentRequest of(String orderId, CardType cardType, String cardNo, BigDecimal amount) {
+        return new PaymentRequest(orderId, cardType, cardNo, amount.toPlainString(), CALLBACK_URL);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRequest.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRequest.java
@@ -12,7 +12,7 @@ public record PaymentRequest(
         String callbackUrl
 ) {
 
-    private static final String CALLBACK_URL = "http://localhost:8080/api/v1/orders/callback";
+    private static final String CALLBACK_URL = "http://localhost:8080/api/v1/payments/callback";
 
     public static PaymentRequest of(String orderId, CardType cardType, String cardNo, BigDecimal amount) {
         return new PaymentRequest(orderId, cardType, cardNo, amount.toPlainString(), CALLBACK_URL);

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PgPaymentApiClient.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PgPaymentApiClient.java
@@ -1,0 +1,38 @@
+package com.loopers.infrastructure.payment;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class PgPaymentApiClient {
+
+    private final RestTemplate restTemplate;
+
+    private static final String PAYMENT_INFO_WITH_TRANSACTION_KEY = "http://localhost:8082/api/v1/payments/";
+
+    public PgPaymentInfoResponse getPaymentInfo(String transactionKey, Long memberId) {
+        String url = PAYMENT_INFO_WITH_TRANSACTION_KEY + transactionKey;
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("X-USER-ID", String.valueOf(memberId));
+
+        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+
+        ResponseEntity<PgPaymentInfoResponse> response =
+                restTemplate.exchange(
+                        url,
+                        HttpMethod.GET,
+                        httpEntity,
+                        new ParameterizedTypeReference<>() {
+                        }
+                );
+
+
+        return response.getBody();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PgPaymentInfoResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PgPaymentInfoResponse.java
@@ -1,0 +1,22 @@
+package com.loopers.infrastructure.payment;
+
+import java.math.BigDecimal;
+
+public record PgPaymentInfoResponse(
+        Meta meta,
+        Data data
+) {
+    public record Meta(String result) {
+    }
+
+    public record Data(
+            String transactionKey,
+            String orderId,
+            String cardType,
+            String cardNo,
+            BigDecimal amount,
+            String status,
+            String reason
+    ) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PgPaymentResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PgPaymentResponse.java
@@ -1,0 +1,9 @@
+package com.loopers.infrastructure.payment;
+
+public record PgPaymentResponse(Meta meta, Data data) {
+    public record Meta(String result) {
+    }
+
+    public record Data(String transactionKey, String status, String reason) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PgPaymentResponse.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PgPaymentResponse.java
@@ -1,7 +1,7 @@
 package com.loopers.infrastructure.payment;
 
 public record PgPaymentResponse(Meta meta, Data data) {
-    public record Meta(String result) {
+    public record Meta(String result, String errorCode, String message) {
     }
 
     public record Data(String transactionKey, String status, String reason) {

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
@@ -2,10 +2,10 @@ package com.loopers.infrastructure.point;
 
 import com.loopers.domain.point.Point;
 import com.loopers.domain.point.PointRepository;
-import com.loopers.support.error.CommonErrorType;
-import com.loopers.support.error.CoreException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -14,15 +14,13 @@ public class PointRepositoryImpl implements PointRepository {
     private final PointJpaRepository pointJpaRepository;
 
     @Override
-    public Point findByMemberIdWithLock(Long memberId) {
-        return pointJpaRepository.findByMemberIdWitkLock(memberId)
-                .orElseThrow(() -> new CoreException(CommonErrorType.NOT_FOUND, "사용자의 포인트를 찾을 수 없습니다. memberId: " + memberId));
+    public Optional<Point> findByMemberIdWithLock(Long memberId) {
+        return pointJpaRepository.findByMemberIdWitkLock(memberId);
     }
 
     @Override
-    public Point findByMemberId(Long memberId) {
-        return pointJpaRepository.findByMemberId(memberId)
-                .orElseThrow(() -> new CoreException(CommonErrorType.NOT_FOUND, "사용자의 포인트를 찾을 수 없습니다. memberId: " + memberId));
+    public Optional<Point> findByMemberId(Long memberId) {
+        return pointJpaRepository.findByMemberId(memberId);
     }
 
     @Override
@@ -31,8 +29,7 @@ public class PointRepositoryImpl implements PointRepository {
     }
 
     @Override
-    public Point findById(Long id) {
-        return pointJpaRepository.findById(id)
-                .orElseThrow(() -> new CoreException(CommonErrorType.NOT_FOUND, "포인트를 찾을 수 없습니다. id: " + id));
+    public Optional<Point> findById(Long id) {
+        return pointJpaRepository.findById(id);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/stock/StockRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/stock/StockRepositoryImpl.java
@@ -2,6 +2,8 @@ package com.loopers.infrastructure.stock;
 
 import com.loopers.domain.stock.Stock;
 import com.loopers.domain.stock.StockRepository;
+import com.loopers.support.error.CommonErrorType;
+import com.loopers.support.error.CoreException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -15,13 +17,13 @@ public class StockRepositoryImpl implements StockRepository {
     @Override
     public Stock findByProductIdWithLock(Long productId) {
         return stockJpaRepository.findByProductIdWithLock(productId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 상품의 재고를 찾을 수 없습니다. productId: " + productId));
+                .orElseThrow(() -> new CoreException(CommonErrorType.NOT_FOUND, "해당 상품의 재고를 찾을 수 없습니다. productId: " + productId));
     }
 
     @Override
     public Stock findByProductId(Long productId) {
         return stockJpaRepository.findByProductId(productId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 상품의 재고를 찾을 수 없습니다. productId: " + productId));
+                .orElseThrow(() -> new CoreException(CommonErrorType.NOT_FOUND, "해당 상품의 재고를 찾을 수 없습니다. productId: " + productId));
     }
 
     @Override
@@ -32,6 +34,6 @@ public class StockRepositoryImpl implements StockRepository {
     @Override
     public Stock findById(Long id) {
         return stockJpaRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 재고를 찾을 수 없습니다. id: " + id));
+                .orElseThrow(() -> new CoreException(CommonErrorType.NOT_FOUND, "해당 재고를 찾을 수 없습니다. id: " + id));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/orders/OrdersV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/orders/OrdersV1Controller.java
@@ -1,0 +1,26 @@
+package com.loopers.interfaces.api.orders;
+
+import com.loopers.application.orders.command.PlaceOrderCommand;
+import com.loopers.application.orders.facade.OrdersFacade;
+import com.loopers.application.orders.result.OrdersRegisterInfoResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/orders")
+public class OrdersV1Controller {
+
+    private final OrdersFacade ordersFacade;
+
+    /*
+     * 주문하기
+     * */
+    @PostMapping
+    public OrdersRegisterInfoResult placeOrder(@RequestBody PlaceOrderCommand command) {
+        return ordersFacade.placeOrder(command);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/orders/dto/PaymentCallbackDTO.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/orders/dto/PaymentCallbackDTO.java
@@ -1,0 +1,15 @@
+package com.loopers.interfaces.api.orders.dto;
+
+
+import java.math.BigDecimal;
+
+public record PaymentCallbackDTO(
+        String transactionKey,
+        String orderId,
+        String cardType,
+        String cardNo,
+        BigDecimal amount,
+        String status,
+        String reason
+) {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Controller.java
@@ -1,0 +1,35 @@
+package com.loopers.interfaces.api.payment;
+
+import com.loopers.application.payment.command.PaymentCallbackCommand;
+import com.loopers.application.payment.facade.PaymentFacade;
+import com.loopers.interfaces.api.orders.dto.PaymentCallbackDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/payments")
+public class PaymentV1Controller {
+
+    private final PaymentFacade paymentFacade;
+
+    /*
+     * 결제 콜백 API
+     * */
+    @PostMapping("/callback")
+    public String paymentCallback(@RequestBody PaymentCallbackDTO paymentCallbackDTO) {
+        // 트랜잭션키로 결제 정보 조회
+        paymentFacade.processCallbackPayment(
+                new PaymentCallbackCommand(
+                        paymentCallbackDTO.transactionKey(),
+                        paymentCallbackDTO.orderId()
+                )
+        );
+
+        return "Payment callback processed successfully.";
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/dto/ProductRegisterReqDTO.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/product/dto/ProductRegisterReqDTO.java
@@ -7,6 +7,7 @@ public record ProductRegisterReqDTO(
         String brandId,
         String description,
         String name,
+        Integer stock,
         BigDecimal price
 ) {
 }

--- a/apps/commerce-api/src/main/java/com/loopers/support/util/UUIDUtil.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/util/UUIDUtil.java
@@ -1,0 +1,19 @@
+package com.loopers.support.util;
+
+import org.springframework.stereotype.Component;
+
+/*
+ * UUID를 생성하기 위한 유틸 클래스
+ * */
+@Component
+public class UUIDUtil {
+
+    public static String generateUUID() {
+        return java.util.UUID.randomUUID().toString();
+    }
+
+    public static String generateShortUUID() {
+        return java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    }
+
+}

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -28,7 +28,7 @@ resilience4j:
   retry:
     instances:
       pg-api:
-        maxAttempts: 2           # 총 시도 횟수 (원호출 + 재시도 포함)
+        maxAttempts: 3           # 총 시도 횟수 (원호출 + 재시도 포함)
         waitDuration: 300ms
         retryExceptions:
           - java.net.ConnectException # 연결 실패
@@ -39,13 +39,14 @@ resilience4j:
           - org.springframework.web.client.HttpClientErrorException   # 4xx는 보통 재시도 안함
         enableExponentialBackoff: true
         exponentialBackoffMultiplier: 2.0
+    retry-aspect-order: 0
   circuitbreaker:
     configs:
       default:
         sliding-window-type: count_based # 슬라이딩 윈도우 타입(횟수 기반)
         sliding-window-size: 100 # 슬라이딩 윈도우 크기
-        failure-rate-threshold: 10 # 실패율 임계값(%)
-        minimum-number-of-calls: 2 # 통계 반영 최소 호출 수
+        failure-rate-threshold: 50 # 실패율 임계값(%)
+        minimum-number-of-calls: 20 # 통계 반영 최소 호출 수
         slow-call-rate-threshold: 20 # 느린 호출 비율 임계값(%)
         slow-call-duration-threshold: 1500
         wait-duration-in-open-state: 1000 # 오픈 상태에서 대기 시간(OPEN -> HALF_OPEN)
@@ -54,6 +55,10 @@ resilience4j:
         register-health-indicator: true
         recordExceptions:
           - java.lang.Throwable
+    circuit-breaker-aspect-order: 1
+    instances:
+      pg-api:
+        base-config: default
 
 springdoc:
   use-fqn: true

--- a/apps/commerce-api/src/main/resources/application.yml
+++ b/apps/commerce-api/src/main/resources/application.yml
@@ -24,6 +24,37 @@ spring:
       - logging.yml
       - monitoring.yml
 
+resilience4j:
+  retry:
+    instances:
+      pg-api:
+        maxAttempts: 2           # 총 시도 횟수 (원호출 + 재시도 포함)
+        waitDuration: 300ms
+        retryExceptions:
+          - java.net.ConnectException # 연결 실패
+          - java.net.SocketTimeoutException # 소켓 타임아웃
+          - org.springframework.web.client.HttpServerErrorException   # 5xx
+          - org.springframework.web.client.ResourceAccessException    # 타임아웃/커넥션
+        ignoreExceptions:
+          - org.springframework.web.client.HttpClientErrorException   # 4xx는 보통 재시도 안함
+        enableExponentialBackoff: true
+        exponentialBackoffMultiplier: 2.0
+  circuitbreaker:
+    configs:
+      default:
+        sliding-window-type: count_based # 슬라이딩 윈도우 타입(횟수 기반)
+        sliding-window-size: 100 # 슬라이딩 윈도우 크기
+        failure-rate-threshold: 10 # 실패율 임계값(%)
+        minimum-number-of-calls: 2 # 통계 반영 최소 호출 수
+        slow-call-rate-threshold: 20 # 느린 호출 비율 임계값(%)
+        slow-call-duration-threshold: 1500
+        wait-duration-in-open-state: 1000 # 오픈 상태에서 대기 시간(OPEN -> HALF_OPEN)
+        permitted-number-of-calls-in-half-open-state: 1 # HALF_OPEN 상태에서 허용되는 호출 수
+        event-consumer-buffer-size: 1
+        register-health-indicator: true
+        recordExceptions:
+          - java.lang.Throwable
+
 springdoc:
   use-fqn: true
   swagger-ui:

--- a/apps/commerce-api/src/test/java/com/loopers/application/orders/OrderFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/orders/OrderFacadeIntegrationTest.java
@@ -410,7 +410,7 @@ public class OrderFacadeIntegrationTest {
 
                 // then
                 List<OrdersInfoResult> ordersList = ordersFacade.getOrdersByMemberId(setUpMember.getId());
-                Point point = pointRepository.findByMemberId(setUpMember.getId());
+                Point point = pointRepository.findByMemberId(setUpMember.getId()).get();
 
                 assertAll(
                         () -> assertNotNull(ordersList),
@@ -539,7 +539,7 @@ public class OrderFacadeIntegrationTest {
             ordersFacade.placeOrder(placeOrderCommand);
 
             // Then
-            Point updatedPoint = pointRepository.findById(setUpPoint.getId());
+            Point updatedPoint = pointRepository.findById(setUpPoint.getId()).get();
             Stock updatedStock = stockRepository.findById(setUpStock.getId());
 
             BigDecimal totalCost = BigDecimal.valueOf((long) quantity1 * price1 + (long) quantity2 * price2);

--- a/apps/commerce-api/src/test/java/com/loopers/application/orders/OrderFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/orders/OrderFacadeIntegrationTest.java
@@ -13,6 +13,8 @@ import com.loopers.domain.couponmember.CouponMemberRepository;
 import com.loopers.domain.member.Member;
 import com.loopers.domain.member.MemberRepository;
 import com.loopers.domain.orders.OrderStatus;
+import com.loopers.domain.payment.CardType;
+import com.loopers.domain.payment.PaymentType;
 import com.loopers.domain.point.Point;
 import com.loopers.domain.point.PointRepository;
 import com.loopers.domain.product.Product;
@@ -119,7 +121,10 @@ public class OrderFacadeIntegrationTest {
             PlaceOrderCommand placeOrderCommand = PlaceOrderCommand.of(
                     setUpMember.getId(),
                     items,
-                    null
+                    null,
+                    PaymentType.CARD,
+                    CardType.SAMSUNG,
+                    "1234-1234-1234-1234"
             );
 
             OrdersRegisterInfoResult ordersRegisterInfoResult = ordersFacade.placeOrder(placeOrderCommand);
@@ -158,7 +163,10 @@ public class OrderFacadeIntegrationTest {
             PlaceOrderCommand placeOrderCommand = PlaceOrderCommand.of(
                     setUpMember.getId(),
                     items,
-                    couponMember.getCouponId()
+                    couponMember.getCouponId(),
+                    PaymentType.POINT,
+                    null,
+                    null
             );
 
             // When
@@ -200,7 +208,10 @@ public class OrderFacadeIntegrationTest {
             PlaceOrderCommand placeOrderCommand = PlaceOrderCommand.of(
                     setUpMember.getId(),
                     items,
-                    couponMember.getCouponId()
+                    couponMember.getCouponId(),
+                    PaymentType.POINT,
+                    null,
+                    null
             );
 
             // When
@@ -242,7 +253,10 @@ public class OrderFacadeIntegrationTest {
             PlaceOrderCommand placeOrderCommand = PlaceOrderCommand.of(
                     setUpMember.getId(),
                     items,
-                    couponMember.getCouponId()
+                    couponMember.getCouponId(),
+                    PaymentType.POINT,
+                    null,
+                    null
             );
 
             // When & Then
@@ -265,6 +279,9 @@ public class OrderFacadeIntegrationTest {
                 PlaceOrderCommand placeOrderCommand = PlaceOrderCommand.of(
                         setUpMember.getId(),
                         items,
+                        null,
+                        PaymentType.POINT,
+                        null,
                         null
                 );
 
@@ -327,7 +344,10 @@ public class OrderFacadeIntegrationTest {
                 PlaceOrderCommand placeOrderCommand = PlaceOrderCommand.of(
                         setUpMember.getId(),
                         items,
-                        couponMember.getCouponId()
+                        couponMember.getCouponId(),
+                        PaymentType.POINT,
+                        null,
+                        null
                 );
 
                 int threadCount = 10;
@@ -371,11 +391,17 @@ public class OrderFacadeIntegrationTest {
                 PlaceOrderCommand placeOrderCommand1 = PlaceOrderCommand.of(
                         setUpMember.getId(),
                         items1,
+                        null,
+                        PaymentType.POINT,
+                        null,
                         null
                 );
                 PlaceOrderCommand placeOrderCommand2 = PlaceOrderCommand.of(
                         setUpMember.getId(),
                         items2,
+                        null,
+                        PaymentType.POINT,
+                        null,
                         null
                 );
 
@@ -429,6 +455,9 @@ public class OrderFacadeIntegrationTest {
                 PlaceOrderCommand placeOrderCommand = PlaceOrderCommand.of(
                         setUpMember.getId(),
                         items,
+                        null,
+                        PaymentType.POINT,
+                        null,
                         null
                 );
 
@@ -487,7 +516,10 @@ public class OrderFacadeIntegrationTest {
             PlaceOrderCommand placeOrderCommand = PlaceOrderCommand.of(
                     setUpMember.getId(),
                     items,
-                    couponMember.getCouponId()
+                    couponMember.getCouponId(),
+                    PaymentType.POINT,
+                    null,
+                    null
             );
 
             // When & Then
@@ -506,7 +538,10 @@ public class OrderFacadeIntegrationTest {
             PlaceOrderCommand placeOrderCommand = PlaceOrderCommand.of(
                     setUpMember.getId(),
                     items,
-                    9999L // 존재하지 않는 쿠폰 ID
+                    9999L, // 존재하지 않는 쿠폰 ID
+                    PaymentType.POINT,
+                    null,
+                    null
             );
 
             // When & Then
@@ -532,6 +567,9 @@ public class OrderFacadeIntegrationTest {
             PlaceOrderCommand placeOrderCommand = PlaceOrderCommand.of(
                     setUpMember.getId(),
                     items,
+                    null,
+                    PaymentType.POINT,
+                    null,
                     null
             );
 
@@ -560,6 +598,9 @@ public class OrderFacadeIntegrationTest {
             PlaceOrderCommand placeOrderCommand = PlaceOrderCommand.of(
                     setUpMember.getId(),
                     items,
+                    null,
+                    PaymentType.POINT,
+                    null,
                     null
             );
 
@@ -578,6 +619,9 @@ public class OrderFacadeIntegrationTest {
             PlaceOrderCommand placeOrderCommand = PlaceOrderCommand.of(
                     setUpMember.getId(),
                     items,
+                    null,
+                    PaymentType.POINT,
+                    null,
                     null
             );
 
@@ -598,6 +642,9 @@ public class OrderFacadeIntegrationTest {
         PlaceOrderCommand placeOrderCommand = PlaceOrderCommand.of(
                 setUpMember.getId(),
                 items,
+                null,
+                PaymentType.POINT,
+                null,
                 null
         );
 

--- a/apps/commerce-api/src/test/java/com/loopers/application/orders/OrderFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/orders/OrderFacadeIntegrationTest.java
@@ -131,7 +131,7 @@ public class OrderFacadeIntegrationTest {
 
             assertAll(
                     () -> assertNotNull(ordersRegisterInfoResult),
-                    () -> assertEquals(OrderStatus.PENDING, ordersRegisterInfoResult.getStatus())
+                    () -> assertEquals(OrderStatus.PENDING, ordersRegisterInfoResult.getOrderStatus())
             );
         }
 
@@ -175,7 +175,7 @@ public class OrderFacadeIntegrationTest {
             // Then
             assertAll(
                     () -> assertNotNull(ordersRegisterInfoResult),
-                    () -> assertEquals(OrderStatus.PENDING, ordersRegisterInfoResult.getStatus()),
+                    () -> assertEquals(OrderStatus.PENDING, ordersRegisterInfoResult.getOrderStatus()),
                     () -> assertEquals(0, ordersRegisterInfoResult.getTotalPrice().compareTo(BigDecimal.valueOf(3000L)))
             );
         }
@@ -220,7 +220,7 @@ public class OrderFacadeIntegrationTest {
             // Then
             assertAll(
                     () -> assertNotNull(ordersRegisterInfoResult),
-                    () -> assertEquals(OrderStatus.PENDING, ordersRegisterInfoResult.getStatus()),
+                    () -> assertEquals(OrderStatus.PENDING, ordersRegisterInfoResult.getOrderStatus()),
                     () -> assertEquals(0, ordersRegisterInfoResult.getTotalPrice().compareTo(BigDecimal.valueOf(3600L)))
             );
         }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/orders/OrdersTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/orders/OrdersTest.java
@@ -1,6 +1,7 @@
 package com.loopers.domain.orders;
 
 import com.loopers.support.error.CoreException;
+import com.loopers.support.util.UUIDUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -25,11 +26,12 @@ class OrdersTest {
             BigDecimal totalPrice = BigDecimal.valueOf(1000);
             Long couponMemberId = null;
             boolean couponUsed = false;
+            String orderKey = UUIDUtil.generateUUID();
 
 
             // when & then
             assertThrows(CoreException.class, () -> {
-                Orders.create(memberId, quantity, totalPrice, couponMemberId, couponUsed);
+                Orders.create(memberId, quantity, totalPrice, couponMemberId, couponUsed, orderKey);
             });
         }
 
@@ -42,11 +44,12 @@ class OrdersTest {
             BigDecimal totalPrice = BigDecimal.valueOf(1000);
             Long couponMemberId = null;
             boolean couponUsed = false;
+            String orderKey = UUIDUtil.generateUUID();
 
 
             // when & then
             assertThrows(CoreException.class, () -> {
-                Orders.create(memberId, quantity, totalPrice, couponMemberId, couponUsed);
+                Orders.create(memberId, quantity, totalPrice, couponMemberId, couponUsed, orderKey);
             });
         }
 
@@ -59,10 +62,11 @@ class OrdersTest {
             BigDecimal totalPrice = BigDecimal.valueOf(100);
             Long couponMemberId = null;
             boolean couponUsed = false;
+            String orderKey = UUIDUtil.generateUUID();
 
 
             // when
-            Orders orders = Orders.create(memberId, quantity, totalPrice, couponMemberId, couponUsed);
+            Orders orders = Orders.create(memberId, quantity, totalPrice, couponMemberId, couponUsed, orderKey);
 
             // then
             assertEquals(memberId, orders.getMemberId());

--- a/apps/pg-simulator/README.md
+++ b/apps/pg-simulator/README.md
@@ -1,0 +1,42 @@
+## PG-Simulator (PaymentGateway)
+
+### Description
+Loopback BE 과정을 위해 PaymentGateway 를 시뮬레이션하는 App Module 입니다.
+`local` 프로필로 실행 권장하며, 커머스 서비스와의 동시 실행을 위해 서버 포트가 조정되어 있습니다.
+- server port : 8082
+- actuator port : 8083
+
+### Getting Started
+부트 서버를 아래 명령어 혹은 `intelliJ` 통해 실행해주세요.
+```shell
+./gradlew :apps:pg-simulator:bootRun
+```
+
+API 는 아래와 같이 주어지니, 커머스 서비스와 동시에 실행시킨 후 진행해주시면 됩니다.
+- 결제 요청 API
+- 결제 정보 확인 `by transactionKey`
+- 결제 정보 목록 조회 `by orderId`
+
+```http request
+### 결제 요청
+POST {{pg-simulator}}/api/v1/payments
+X-USER-ID: 135135
+Content-Type: application/json
+
+{
+  "orderId": "1351039135",
+  "cardType": "SAMSUNG",
+  "cardNo": "1234-5678-9814-1451",
+  "amount" : "5000",
+  "callbackUrl": "http://localhost:8080/api/v1/examples/callback"
+}
+
+### 결제 정보 확인
+GET {{pg-simulator}}/api/v1/payments/20250816:TR:9577c5
+X-USER-ID: 135135
+
+### 주문에 엮인 결제 정보 조회
+GET {{pg-simulator}}/api/v1/payments?orderId=1351039135
+X-USER-ID: 135135
+
+```

--- a/apps/pg-simulator/build.gradle.kts
+++ b/apps/pg-simulator/build.gradle.kts
@@ -1,0 +1,40 @@
+plugins {
+    val kotlinVersion = "2.0.20"
+
+    id("org.jetbrains.kotlin.jvm") version(kotlinVersion)
+    id("org.jetbrains.kotlin.kapt") version(kotlinVersion)
+    id("org.jetbrains.kotlin.plugin.spring") version(kotlinVersion)
+    id("org.jetbrains.kotlin.plugin.jpa") version(kotlinVersion)
+}
+
+kotlin {
+    compilerOptions {
+        jvmToolchain(21)
+        freeCompilerArgs.addAll("-Xjsr305=strict")
+    }
+}
+
+dependencies {
+    // add-ons
+    implementation(project(":modules:jpa"))
+    implementation(project(":modules:redis"))
+    implementation(project(":supports:jackson"))
+    implementation(project(":supports:logging"))
+    implementation(project(":supports:monitoring"))
+
+    // kotlin
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+
+    // web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${project.properties["springDocOpenApiVersion"]}")
+
+    // querydsl
+    kapt("com.querydsl:querydsl-apt::jakarta")
+
+    // test-fixtures
+    testImplementation(testFixtures(project(":modules:jpa")))
+    testImplementation(testFixtures(project(":modules:redis")))
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/PaymentGatewayApplication.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/PaymentGatewayApplication.kt
@@ -1,0 +1,24 @@
+package com.loopers
+
+import jakarta.annotation.PostConstruct
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableAsync
+import java.util.TimeZone
+
+@ConfigurationPropertiesScan
+@EnableAsync
+@SpringBootApplication
+class PaymentGatewayApplication {
+
+    @PostConstruct
+    fun started() {
+        // set timezone
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))
+    }
+}
+
+fun main(args: Array<String>) {
+    runApplication<PaymentGatewayApplication>(*args)
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/OrderInfo.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/OrderInfo.kt
@@ -1,0 +1,14 @@
+package com.loopers.application.payment
+
+/**
+ * 결제 주문 정보
+ *
+ * 결제는 주문에 대한 다수 트랜잭션으로 구성됩니다.
+ *
+ * @property orderId 주문 정보
+ * @property transactions 주문에 엮인 트랜잭션 목록
+ */
+data class OrderInfo(
+    val orderId: String,
+    val transactions: List<TransactionInfo>,
+)

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentApplicationService.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentApplicationService.kt
@@ -1,0 +1,88 @@
+package com.loopers.application.payment
+
+import com.loopers.domain.payment.Payment
+import com.loopers.domain.payment.PaymentEvent
+import com.loopers.domain.payment.PaymentEventPublisher
+import com.loopers.domain.payment.PaymentRelay
+import com.loopers.domain.payment.PaymentRepository
+import com.loopers.domain.payment.TransactionKeyGenerator
+import com.loopers.domain.user.UserInfo
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class PaymentApplicationService(
+    private val paymentRepository: PaymentRepository,
+    private val paymentEventPublisher: PaymentEventPublisher,
+    private val paymentRelay: PaymentRelay,
+    private val transactionKeyGenerator: TransactionKeyGenerator,
+) {
+    companion object {
+        private val RATE_LIMIT_EXCEEDED = (1..20)
+        private val RATE_INVALID_CARD = (21..30)
+    }
+
+    @Transactional
+    fun createTransaction(command: PaymentCommand.CreateTransaction): TransactionInfo {
+        command.validate()
+
+        val transactionKey = transactionKeyGenerator.generate()
+        val payment = paymentRepository.save(
+            Payment(
+                transactionKey = transactionKey,
+                userId = command.userId,
+                orderId = command.orderId,
+                cardType = command.cardType,
+                cardNo = command.cardNo,
+                amount = command.amount,
+                callbackUrl = command.callbackUrl,
+            ),
+        )
+
+        paymentEventPublisher.publish(PaymentEvent.PaymentCreated.from(payment = payment))
+
+        return TransactionInfo.from(payment)
+    }
+
+    @Transactional(readOnly = true)
+    fun getTransactionDetailInfo(userInfo: UserInfo, transactionKey: String): TransactionInfo {
+        val payment = paymentRepository.findByTransactionKey(userId = userInfo.userId, transactionKey = transactionKey)
+            ?: throw CoreException(ErrorType.NOT_FOUND, "(transactionKey: $transactionKey) 결제건이 존재하지 않습니다.")
+        return TransactionInfo.from(payment)
+    }
+
+    @Transactional(readOnly = true)
+    fun findTransactionsByOrderId(userInfo: UserInfo, orderId: String): OrderInfo {
+        val payments = paymentRepository.findByOrderId(userId = userInfo.userId, orderId = orderId)
+        if (payments.isEmpty()) {
+            throw CoreException(ErrorType.NOT_FOUND, "(orderId: $orderId) 에 해당하는 결제건이 존재하지 않습니다.")
+        }
+
+        return OrderInfo(
+            orderId = orderId,
+            transactions = payments.map { TransactionInfo.from(it) },
+        )
+    }
+
+    @Transactional
+    fun handle(transactionKey: String) {
+        val payment = paymentRepository.findByTransactionKey(transactionKey)
+            ?: throw CoreException(ErrorType.NOT_FOUND, "(transactionKey: $transactionKey) 결제건이 존재하지 않습니다.")
+
+        val rate = (1..100).random()
+        when (rate) {
+            in RATE_LIMIT_EXCEEDED -> payment.limitExceeded()
+            in RATE_INVALID_CARD -> payment.invalidCard()
+            else -> payment.approve()
+        }
+        paymentEventPublisher.publish(event = PaymentEvent.PaymentHandled.from(payment))
+    }
+
+    fun notifyTransactionResult(transactionKey: String) {
+        val payment = paymentRepository.findByTransactionKey(transactionKey)
+            ?: throw CoreException(ErrorType.NOT_FOUND, "(transactionKey: $transactionKey) 결제건이 존재하지 않습니다.")
+        paymentRelay.notify(callbackUrl = payment.callbackUrl, transactionInfo = TransactionInfo.from(payment))
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentCommand.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/PaymentCommand.kt
@@ -1,0 +1,22 @@
+package com.loopers.application.payment
+
+import com.loopers.domain.payment.CardType
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+
+object PaymentCommand {
+    data class CreateTransaction(
+        val userId: String,
+        val orderId: String,
+        val cardType: CardType,
+        val cardNo: String,
+        val amount: Long,
+        val callbackUrl: String,
+    ) {
+        fun validate() {
+            if (amount <= 0L) {
+                throw CoreException(ErrorType.BAD_REQUEST, "요청 금액은 0 보다 큰 정수여야 합니다.")
+            }
+        }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/TransactionInfo.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/application/payment/TransactionInfo.kt
@@ -1,0 +1,39 @@
+package com.loopers.application.payment
+
+import com.loopers.domain.payment.CardType
+import com.loopers.domain.payment.Payment
+import com.loopers.domain.payment.TransactionStatus
+
+/**
+ * 트랜잭션 정보
+ *
+ * @property transactionKey 트랜잭션 KEY
+ * @property orderId 주문 ID
+ * @property cardType 카드 종류
+ * @property cardNo 카드 번호
+ * @property amount 금액
+ * @property status 처리 상태
+ * @property reason 처리 사유
+ */
+data class TransactionInfo(
+    val transactionKey: String,
+    val orderId: String,
+    val cardType: CardType,
+    val cardNo: String,
+    val amount: Long,
+    val status: TransactionStatus,
+    val reason: String?,
+) {
+    companion object {
+        fun from(payment: Payment): TransactionInfo =
+            TransactionInfo(
+                transactionKey = payment.transactionKey,
+                orderId = payment.orderId,
+                cardType = payment.cardType,
+                cardNo = payment.cardNo,
+                amount = payment.amount,
+                status = payment.status,
+                reason = payment.reason,
+            )
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/config/web/WebMvcConfig.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/config/web/WebMvcConfig.kt
@@ -1,0 +1,13 @@
+package com.loopers.config.web
+
+import com.loopers.interfaces.api.argumentresolver.UserInfoArgumentResolver
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig : WebMvcConfigurer {
+    override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver?>) {
+        resolvers.add(UserInfoArgumentResolver())
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/CardType.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/CardType.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment
+
+enum class CardType {
+    SAMSUNG,
+    KB,
+    HYUNDAI,
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/Payment.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/Payment.kt
@@ -1,0 +1,87 @@
+package com.loopers.domain.payment
+
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "payments",
+    indexes = [
+        Index(name = "idx_user_transaction", columnList = "user_id, transaction_key"),
+        Index(name = "idx_user_order", columnList = "user_id, order_id"),
+        Index(name = "idx_unique_user_order_transaction", columnList = "user_id, order_id, transaction_key", unique = true),
+    ]
+)
+class Payment(
+    @Id
+    @Column(name = "transaction_key", nullable = false, unique = true)
+    val transactionKey: String,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: String,
+
+    @Column(name = "order_id", nullable = false)
+    val orderId: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "card_type", nullable = false)
+    val cardType: CardType,
+
+    @Column(name = "card_no", nullable = false)
+    val cardNo: String,
+
+    @Column(name = "amount", nullable = false)
+    val amount: Long,
+
+    @Column(name = "callback_url", nullable = false)
+    val callbackUrl: String,
+) {
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    var status: TransactionStatus = TransactionStatus.PENDING
+        private set
+
+    @Column(name = "reason", nullable = true)
+    var reason: String? = null
+        private set
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now()
+        private set
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+        private set
+
+    fun approve() {
+        if (status != TransactionStatus.PENDING) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "결제승인은 대기상태에서만 가능합니다.")
+        }
+        status = TransactionStatus.SUCCESS
+        reason = "정상 승인되었습니다."
+    }
+
+    fun invalidCard() {
+        if (status != TransactionStatus.PENDING) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "결제처리는 대기상태에서만 가능합니다.")
+        }
+        status = TransactionStatus.FAILED
+        reason = "잘못된 카드입니다. 다른 카드를 선택해주세요."
+    }
+
+    fun limitExceeded() {
+        if (status != TransactionStatus.PENDING) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "한도초과 처리는 대기상태에서만 가능합니다.")
+        }
+        status = TransactionStatus.FAILED
+        reason = "한도초과입니다. 다른 카드를 선택해주세요."
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEvent.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEvent.kt
@@ -1,0 +1,28 @@
+package com.loopers.domain.payment
+
+object PaymentEvent {
+    data class PaymentCreated(
+        val transactionKey: String,
+    ) {
+        companion object {
+            fun from(payment: Payment): PaymentCreated = PaymentCreated(transactionKey = payment.transactionKey)
+        }
+    }
+
+    data class PaymentHandled(
+        val transactionKey: String,
+        val status: TransactionStatus,
+        val reason: String?,
+        val callbackUrl: String,
+    ) {
+        companion object {
+            fun from(payment: Payment): PaymentHandled =
+                PaymentHandled(
+                    transactionKey = payment.transactionKey,
+                    status = payment.status,
+                    reason = payment.reason,
+                    callbackUrl = payment.callbackUrl,
+                )
+        }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEventPublisher.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentEventPublisher.kt
@@ -1,0 +1,6 @@
+package com.loopers.domain.payment
+
+interface PaymentEventPublisher {
+    fun publish(event: PaymentEvent.PaymentCreated)
+    fun publish(event: PaymentEvent.PaymentHandled)
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRelay.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRelay.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment
+
+import com.loopers.application.payment.TransactionInfo
+
+interface PaymentRelay {
+    fun notify(callbackUrl: String, transactionInfo: TransactionInfo)
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRepository.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/PaymentRepository.kt
@@ -1,0 +1,8 @@
+package com.loopers.domain.payment
+
+interface PaymentRepository {
+    fun save(payment: Payment): Payment
+    fun findByTransactionKey(transactionKey: String): Payment?
+    fun findByTransactionKey(userId: String, transactionKey: String): Payment?
+    fun findByOrderId(userId: String, orderId: String): List<Payment>
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionKeyGenerator.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionKeyGenerator.kt
@@ -1,0 +1,20 @@
+package com.loopers.domain.payment
+
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+@Component
+class TransactionKeyGenerator {
+    companion object {
+        private const val KEY_TRANSACTION = "TR"
+        private val DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd")
+    }
+
+    fun generate(): String {
+        val now = LocalDateTime.now()
+        val uuid = UUID.randomUUID().toString().replace("-", "").substring(0, 6)
+        return "${DATETIME_FORMATTER.format(now)}:$KEY_TRANSACTION:$uuid"
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionStatus.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/payment/TransactionStatus.kt
@@ -1,0 +1,7 @@
+package com.loopers.domain.payment
+
+enum class TransactionStatus {
+    PENDING,
+    SUCCESS,
+    FAILED
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/domain/user/UserInfo.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/domain/user/UserInfo.kt
@@ -1,0 +1,8 @@
+package com.loopers.domain.user
+
+/**
+ * user 정보
+ *
+ * @param userId 유저 식별자
+ */
+data class UserInfo(val userId: String)

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreEventPublisher.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreEventPublisher.kt
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.PaymentEvent
+import com.loopers.domain.payment.PaymentEventPublisher
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+@Component
+class PaymentCoreEventPublisher(
+    private val applicationEventPublisher: ApplicationEventPublisher,
+) : PaymentEventPublisher {
+    override fun publish(event: PaymentEvent.PaymentCreated) {
+        applicationEventPublisher.publishEvent(event)
+    }
+
+    override fun publish(event: PaymentEvent.PaymentHandled) {
+        applicationEventPublisher.publishEvent(event)
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRelay.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRelay.kt
@@ -1,0 +1,21 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.application.payment.TransactionInfo
+import com.loopers.domain.payment.PaymentRelay
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestTemplate
+
+@Component
+class PaymentCoreRelay : PaymentRelay {
+    companion object {
+        private val logger = LoggerFactory.getLogger(PaymentCoreRelay::class.java)
+        private val restTemplate = RestTemplate()
+    }
+
+    override fun notify(callbackUrl: String, transactionInfo: TransactionInfo) {
+        runCatching {
+            restTemplate.postForEntity(callbackUrl, transactionInfo, Any::class.java)
+        }.onFailure { e -> logger.error("콜백 호출을 실패했습니다. {}", e.message, e) }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRepository.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentCoreRepository.kt
@@ -1,0 +1,32 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.Payment
+import com.loopers.domain.payment.PaymentRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import kotlin.jvm.optionals.getOrNull
+
+@Component
+class PaymentCoreRepository(
+    private val paymentJpaRepository: PaymentJpaRepository,
+) : PaymentRepository {
+    @Transactional
+    override fun save(payment: Payment): Payment {
+        return paymentJpaRepository.save(payment)
+    }
+
+    @Transactional(readOnly = true)
+    override fun findByTransactionKey(transactionKey: String): Payment? {
+        return paymentJpaRepository.findById(transactionKey).getOrNull()
+    }
+
+    @Transactional(readOnly = true)
+    override fun findByTransactionKey(userId: String, transactionKey: String): Payment? {
+        return paymentJpaRepository.findByUserIdAndTransactionKey(userId, transactionKey)
+    }
+
+    override fun findByOrderId(userId: String, orderId: String): List<Payment> {
+        return paymentJpaRepository.findByUserIdAndOrderId(userId, orderId)
+            .sortedByDescending { it.updatedAt }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentJpaRepository.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/infrastructure/payment/PaymentJpaRepository.kt
@@ -1,0 +1,9 @@
+package com.loopers.infrastructure.payment
+
+import com.loopers.domain.payment.Payment
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PaymentJpaRepository : JpaRepository<Payment, String> {
+    fun findByUserIdAndTransactionKey(userId: String, transactionKey: String): Payment?
+    fun findByUserIdAndOrderId(userId: String, orderId: String): List<Payment>
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiControllerAdvice.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiControllerAdvice.kt
@@ -1,0 +1,119 @@
+package com.loopers.interfaces.api
+
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.slf4j.LoggerFactory
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MissingServletRequestParameterException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.server.ServerWebInputException
+import org.springframework.web.servlet.resource.NoResourceFoundException
+import kotlin.collections.joinToString
+import kotlin.jvm.java
+import kotlin.text.isNotEmpty
+import kotlin.text.toRegex
+
+@RestControllerAdvice
+class ApiControllerAdvice {
+    private val log = LoggerFactory.getLogger(ApiControllerAdvice::class.java)
+
+    @ExceptionHandler
+    fun handle(e: CoreException): ResponseEntity<ApiResponse<*>> {
+        log.warn("CoreException : {}", e.customMessage ?: e.message, e)
+        return failureResponse(errorType = e.errorType, errorMessage = e.customMessage)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: MethodArgumentTypeMismatchException): ResponseEntity<ApiResponse<*>> {
+        val name = e.name
+        val type = e.requiredType?.simpleName ?: "unknown"
+        val value = e.value ?: "null"
+        val message = "요청 파라미터 '$name' (타입: $type)의 값 '$value'이(가) 잘못되었습니다."
+        return failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = message)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: MissingServletRequestParameterException): ResponseEntity<ApiResponse<*>> {
+        val name = e.parameterName
+        val type = e.parameterType
+        val message = "필수 요청 파라미터 '$name' (타입: $type)가 누락되었습니다."
+        return failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = message)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: HttpMessageNotReadableException): ResponseEntity<ApiResponse<*>> {
+        val errorMessage = when (val rootCause = e.rootCause) {
+            is InvalidFormatException -> {
+                val fieldName = rootCause.path.joinToString(".") { it.fieldName ?: "?" }
+
+                val valueIndicationMessage = when {
+                    rootCause.targetType.isEnum -> {
+                        val enumClass = rootCause.targetType
+                        val enumValues = enumClass.enumConstants.joinToString(", ") { it.toString() }
+                        "사용 가능한 값 : [$enumValues]"
+                    }
+
+                    else -> ""
+                }
+
+                val expectedType = rootCause.targetType.simpleName
+                val value = rootCause.value
+
+                "필드 '$fieldName'의 값 '$value'이(가) 예상 타입($expectedType)과 일치하지 않습니다. $valueIndicationMessage"
+            }
+
+            is MismatchedInputException -> {
+                val fieldPath = rootCause.path.joinToString(".") { it.fieldName ?: "?" }
+                "필수 필드 '$fieldPath'이(가) 누락되었습니다."
+            }
+
+            is JsonMappingException -> {
+                val fieldPath = rootCause.path.joinToString(".") { it.fieldName ?: "?" }
+                "필드 '$fieldPath'에서 JSON 매핑 오류가 발생했습니다: ${rootCause.originalMessage}"
+            }
+
+            else -> "요청 본문을 처리하는 중 오류가 발생했습니다. JSON 메세지 규격을 확인해주세요."
+        }
+
+        return failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = errorMessage)
+    }
+
+    @ExceptionHandler
+    fun handleBadRequest(e: ServerWebInputException): ResponseEntity<ApiResponse<*>> {
+        fun extractMissingParameter(message: String): String {
+            val regex = "'(.+?)'".toRegex()
+            return regex.find(message)?.groupValues?.get(1) ?: ""
+        }
+
+        val missingParams = extractMissingParameter(e.reason ?: "")
+        return if (missingParams.isNotEmpty()) {
+            failureResponse(errorType = ErrorType.BAD_REQUEST, errorMessage = "필수 요청 값 \'$missingParams\'가 누락되었습니다.")
+        } else {
+            failureResponse(errorType = ErrorType.BAD_REQUEST)
+        }
+    }
+
+    @ExceptionHandler
+    fun handleNotFound(e: NoResourceFoundException): ResponseEntity<ApiResponse<*>> {
+        return failureResponse(errorType = ErrorType.NOT_FOUND)
+    }
+
+    @ExceptionHandler
+    fun handle(e: Throwable): ResponseEntity<ApiResponse<*>> {
+        log.error("Exception : {}", e.message, e)
+        val errorType = ErrorType.INTERNAL_ERROR
+        return failureResponse(errorType = errorType)
+    }
+
+    private fun failureResponse(errorType: ErrorType, errorMessage: String? = null): ResponseEntity<ApiResponse<*>> =
+        ResponseEntity(
+            ApiResponse.fail(errorCode = errorType.code, errorMessage = errorMessage ?: errorType.message),
+            errorType.status,
+        )
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiResponse.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/ApiResponse.kt
@@ -1,0 +1,32 @@
+package com.loopers.interfaces.api
+
+data class ApiResponse<T>(
+    val meta: Metadata,
+    val data: T?,
+) {
+    data class Metadata(
+        val result: Result,
+        val errorCode: String?,
+        val message: String?,
+    ) {
+        enum class Result { SUCCESS, FAIL }
+
+        companion object {
+            fun success() = Metadata(Result.SUCCESS, null, null)
+
+            fun fail(errorCode: String, errorMessage: String) = Metadata(Result.FAIL, errorCode, errorMessage)
+        }
+    }
+
+    companion object {
+        fun success(): ApiResponse<Any> = ApiResponse(Metadata.success(), null)
+
+        fun <T> success(data: T? = null) = ApiResponse(Metadata.success(), data)
+
+        fun fail(errorCode: String, errorMessage: String): ApiResponse<Any?> =
+            ApiResponse(
+                meta = Metadata.fail(errorCode = errorCode, errorMessage = errorMessage),
+                data = null,
+            )
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/argumentresolver/UserInfoArgumentResolver.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/argumentresolver/UserInfoArgumentResolver.kt
@@ -1,0 +1,32 @@
+package com.loopers.interfaces.api.argumentresolver
+
+import com.loopers.domain.user.UserInfo
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.core.MethodParameter
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+class UserInfoArgumentResolver: HandlerMethodArgumentResolver {
+    companion object {
+        private const val KEY_USER_ID = "X-USER-ID"
+    }
+
+    override fun supportsParameter(parameter: MethodParameter): Boolean {
+        return UserInfo::class.java.isAssignableFrom(parameter.parameterType)
+    }
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?,
+    ): UserInfo {
+        val userId = webRequest.getHeader(KEY_USER_ID)
+            ?: throw CoreException(ErrorType.BAD_REQUEST, "유저 ID 헤더는 필수입니다.")
+
+        return UserInfo(userId)
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentApi.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentApi.kt
@@ -1,0 +1,60 @@
+package com.loopers.interfaces.api.payment
+
+import com.loopers.application.payment.PaymentApplicationService
+import com.loopers.interfaces.api.ApiResponse
+import com.loopers.domain.user.UserInfo
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/payments")
+class PaymentApi(
+    private val paymentApplicationService: PaymentApplicationService,
+) {
+    @PostMapping
+    fun request(
+        userInfo: UserInfo,
+        @RequestBody request: PaymentDto.PaymentRequest,
+    ): ApiResponse<PaymentDto.TransactionResponse> {
+        request.validate()
+
+        // 100ms ~ 500ms 지연
+        Thread.sleep((100..500L).random())
+
+        // 40% 확률로 요청 실패
+        if ((1..100).random() <= 40) {
+            throw CoreException(ErrorType.INTERNAL_ERROR, "현재 서버가 불안정합니다. 잠시 후 다시 시도해주세요.")
+        }
+
+        return paymentApplicationService.createTransaction(request.toCommand(userInfo.userId))
+            .let { PaymentDto.TransactionResponse.from(it) }
+            .let { ApiResponse.success(it) }
+    }
+
+    @GetMapping("/{transactionKey}")
+    fun getTransaction(
+        userInfo: UserInfo,
+        @PathVariable("transactionKey") transactionKey: String,
+    ): ApiResponse<PaymentDto.TransactionDetailResponse> {
+        return paymentApplicationService.getTransactionDetailInfo(userInfo, transactionKey)
+            .let { PaymentDto.TransactionDetailResponse.from(it) }
+            .let { ApiResponse.success(it) }
+    }
+
+    @GetMapping
+    fun getTransactionsByOrder(
+        userInfo: UserInfo,
+        @RequestParam("orderId", required = false) orderId: String,
+    ): ApiResponse<PaymentDto.OrderResponse> {
+        return paymentApplicationService.findTransactionsByOrderId(userInfo, orderId)
+            .let { PaymentDto.OrderResponse.from(it) }
+            .let { ApiResponse.success(it) }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentApi.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentApi.kt
@@ -23,7 +23,7 @@ class PaymentApi(
         Thread.sleep((100..500L).random())
 
         // 40% 확률로 요청 실패
-        if ((1..100).random() <= 70) {
+        if ((1..100).random() <= 40) {
             throw CoreException(ErrorType.INTERNAL_ERROR, "현재 서버가 불안정합니다. 잠시 후 다시 시도해주세요.")
         }
 

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentApi.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentApi.kt
@@ -1,17 +1,11 @@
 package com.loopers.interfaces.api.payment
 
 import com.loopers.application.payment.PaymentApplicationService
-import com.loopers.interfaces.api.ApiResponse
 import com.loopers.domain.user.UserInfo
+import com.loopers.interfaces.api.ApiResponse
 import com.loopers.support.error.CoreException
 import com.loopers.support.error.ErrorType
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/payments")
@@ -29,7 +23,7 @@ class PaymentApi(
         Thread.sleep((100..500L).random())
 
         // 40% 확률로 요청 실패
-        if ((1..100).random() <= 40) {
+        if ((1..100).random() <= 70) {
             throw CoreException(ErrorType.INTERNAL_ERROR, "현재 서버가 불안정합니다. 잠시 후 다시 시도해주세요.")
         }
 

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentDto.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/api/payment/PaymentDto.kt
@@ -1,0 +1,136 @@
+package com.loopers.interfaces.api.payment
+
+import com.loopers.application.payment.OrderInfo
+import com.loopers.application.payment.PaymentCommand
+import com.loopers.application.payment.TransactionInfo
+import com.loopers.domain.payment.CardType
+import com.loopers.domain.payment.TransactionStatus
+import com.loopers.support.error.CoreException
+import com.loopers.support.error.ErrorType
+
+object PaymentDto {
+    data class PaymentRequest(
+        val orderId: String,
+        val cardType: CardTypeDto,
+        val cardNo: String,
+        val amount: Long,
+        val callbackUrl: String,
+    ) {
+        companion object {
+            private val REGEX_CARD_NO = Regex("^\\d{4}-\\d{4}-\\d{4}-\\d{4}$")
+            private const val PREFIX_CALLBACK_URL = "http://localhost:8080"
+        }
+
+        fun validate() {
+            if (orderId.isBlank() || orderId.length < 6) {
+                throw CoreException(ErrorType.BAD_REQUEST, "주문 ID는 6자리 이상 문자열이어야 합니다.")
+            }
+            if (!REGEX_CARD_NO.matches(cardNo)) {
+                throw CoreException(ErrorType.BAD_REQUEST, "카드 번호는 xxxx-xxxx-xxxx-xxxx 형식이어야 합니다.")
+            }
+            if (amount <= 0) {
+                throw CoreException(ErrorType.BAD_REQUEST, "결제금액은 양의 정수여야 합니다.")
+            }
+            if (!callbackUrl.startsWith(PREFIX_CALLBACK_URL)) {
+                throw CoreException(ErrorType.BAD_REQUEST, "콜백 URL 은 $PREFIX_CALLBACK_URL 로 시작해야 합니다.")
+            }
+        }
+
+        fun toCommand(userId: String): PaymentCommand.CreateTransaction =
+            PaymentCommand.CreateTransaction(
+                userId = userId,
+                orderId = orderId,
+                cardType = cardType.toCardType(),
+                cardNo = cardNo,
+                amount = amount,
+                callbackUrl = callbackUrl,
+            )
+    }
+
+    data class TransactionDetailResponse(
+        val transactionKey: String,
+        val orderId: String,
+        val cardType: CardTypeDto,
+        val cardNo: String,
+        val amount: Long,
+        val status: TransactionStatusResponse,
+        val reason: String?,
+    ) {
+        companion object {
+            fun from(transactionInfo: TransactionInfo): TransactionDetailResponse =
+                TransactionDetailResponse(
+                    transactionKey = transactionInfo.transactionKey,
+                    orderId = transactionInfo.orderId,
+                    cardType = CardTypeDto.from(transactionInfo.cardType),
+                    cardNo = transactionInfo.cardNo,
+                    amount = transactionInfo.amount,
+                    status = TransactionStatusResponse.from(transactionInfo.status),
+                    reason = transactionInfo.reason,
+                )
+        }
+    }
+
+    data class TransactionResponse(
+        val transactionKey: String,
+        val status: TransactionStatusResponse,
+        val reason: String?,
+    ) {
+        companion object {
+            fun from(transactionInfo: TransactionInfo): TransactionResponse =
+                TransactionResponse(
+                    transactionKey = transactionInfo.transactionKey,
+                    status = TransactionStatusResponse.from(transactionInfo.status),
+                    reason = transactionInfo.reason,
+                )
+        }
+    }
+
+    data class OrderResponse(
+        val orderId: String,
+        val transactions: List<TransactionResponse>,
+    ) {
+        companion object {
+            fun from(orderInfo: OrderInfo): OrderResponse =
+                OrderResponse(
+                    orderId = orderInfo.orderId,
+                    transactions = orderInfo.transactions.map { TransactionResponse.from(it) },
+                )
+        }
+    }
+
+    enum class CardTypeDto {
+        SAMSUNG,
+        KB,
+        HYUNDAI,
+        ;
+
+        fun toCardType(): CardType = when (this) {
+            SAMSUNG -> CardType.SAMSUNG
+            KB -> CardType.KB
+            HYUNDAI -> CardType.HYUNDAI
+        }
+
+        companion object {
+            fun from(cardType: CardType) = when (cardType) {
+                CardType.SAMSUNG -> SAMSUNG
+                CardType.KB -> KB
+                CardType.HYUNDAI -> HYUNDAI
+            }
+        }
+    }
+
+    enum class TransactionStatusResponse {
+        PENDING,
+        SUCCESS,
+        FAILED,
+        ;
+
+        companion object {
+            fun from(transactionStatus: TransactionStatus) = when (transactionStatus) {
+                TransactionStatus.PENDING -> PENDING
+                TransactionStatus.SUCCESS -> SUCCESS
+                TransactionStatus.FAILED -> FAILED
+            }
+        }
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/event/payment/PaymentEventListener.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/interfaces/event/payment/PaymentEventListener.kt
@@ -1,0 +1,28 @@
+package com.loopers.interfaces.event.payment
+
+import com.loopers.application.payment.PaymentApplicationService
+import com.loopers.domain.payment.PaymentEvent
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class PaymentEventListener(
+    private val paymentApplicationService: PaymentApplicationService,
+) {
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handle(event: PaymentEvent.PaymentCreated) {
+        val thresholdMillis = (1000L..5000L).random()
+        Thread.sleep(thresholdMillis)
+
+        paymentApplicationService.handle(event.transactionKey)
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handle(event: PaymentEvent.PaymentHandled) {
+        paymentApplicationService.notifyTransactionResult(transactionKey = event.transactionKey)
+    }
+}

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/CoreException.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/CoreException.kt
@@ -1,0 +1,6 @@
+package com.loopers.support.error
+
+class CoreException(
+    val errorType: ErrorType,
+    val customMessage: String? = null,
+) : RuntimeException(customMessage ?: errorType.message)

--- a/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/ErrorType.kt
+++ b/apps/pg-simulator/src/main/kotlin/com/loopers/support/error/ErrorType.kt
@@ -1,0 +1,11 @@
+package com.loopers.support.error
+
+import org.springframework.http.HttpStatus
+
+enum class ErrorType(val status: HttpStatus, val code: String, val message: String) {
+    /** 범용 에러 */
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, HttpStatus.INTERNAL_SERVER_ERROR.reasonPhrase, "일시적인 오류가 발생했습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.reasonPhrase, "잘못된 요청입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.reasonPhrase, "존재하지 않는 요청입니다."),
+    CONFLICT(HttpStatus.CONFLICT, HttpStatus.CONFLICT.reasonPhrase, "이미 존재하는 리소스입니다."),
+}

--- a/apps/pg-simulator/src/main/resources/application.yml
+++ b/apps/pg-simulator/src/main/resources/application.yml
@@ -1,0 +1,77 @@
+server:
+  shutdown: graceful
+  tomcat:
+    threads:
+      max: 200 # 최대 워커 스레드 수 (default : 200)
+      min-spare: 10 # 최소 유지 스레드 수 (default : 10)
+    connection-timeout: 1m # 연결 타임아웃 (ms) (default : 60000ms = 1m)
+    max-connections: 8192 # 최대 동시 연결 수 (default : 8192)
+    accept-count: 100 # 대기 큐 크기 (default : 100)
+    keep-alive-timeout: 60s # 60s
+  max-http-request-header-size: 8KB
+
+spring:
+  main:
+    web-application-type: servlet
+  application:
+    name: commerce-api
+  profiles:
+    active: local
+  config:
+    import:
+      - jpa.yml
+      - redis.yml
+      - logging.yml
+      - monitoring.yml
+
+datasource:
+  mysql-jpa:
+    main:
+      jdbc-url: jdbc:mysql://localhost:3306/paymentgateway
+
+springdoc:
+  use-fqn: true
+  swagger-ui:
+    path: /swagger-ui.html
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local, test
+
+server:
+  port: 8082
+
+management:
+  server:
+    port: 8083
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+server:
+  port: 8082
+
+management:
+  server:
+    port: 8083
+
+---
+spring:
+  config:
+    activate:
+      on-profile: qa
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prd
+
+springdoc:
+  api-docs:
+    enabled: false

--- a/http/http-client.env.json
+++ b/http/http-client.env.json
@@ -1,5 +1,6 @@
 {
   "local": {
-    "commerce-api": "http://localhost:8080"
+    "commerce-api": "http://localhost:8080",
+    "pg-simulator": "http://localhost:8082"
   }
 }

--- a/http/pg-simulator/payments.http
+++ b/http/pg-simulator/payments.http
@@ -1,0 +1,20 @@
+### 결제 요청
+POST {{pg-simulator}}/api/v1/payments
+X-USER-ID: 135135
+Content-Type: application/json
+
+{
+  "orderId": "1351039135",
+  "cardType": "SAMSUNG",
+  "cardNo": "1234-5678-9814-1451",
+  "amount": "5000",
+  "callbackUrl": "http://localhost:8080/api/v1/examples/callback"
+}
+
+### 결제 정보 확인
+GET {{pg-simulator}}/api/v1/payments/20250816:TR:9577c5
+X-USER-ID: 135135
+
+### 주문에 엮인 결제 정보 조회
+GET {{pg-simulator}}/api/v1/payments?orderId=1351039135
+X-USER-ID: 135135

--- a/http/pg-simulator/payments.http
+++ b/http/pg-simulator/payments.http
@@ -12,9 +12,9 @@ Content-Type: application/json
 }
 
 ### 결제 정보 확인
-GET {{pg-simulator}}/api/v1/payments/20250821:TR:af061d
-X-USER-ID: 135135
+GET {{pg-simulator}}/api/v1/payments/20250821:TR:036911
+X-USER-ID: 1
 
 ### 주문에 엮인 결제 정보 조회
-GET {{pg-simulator}}/api/v1/payments?orderId=1351039135
+GET {{pg-simulator}}/api/v1/payments?orderId=833b044f
 X-USER-ID: 135135

--- a/http/pg-simulator/payments.http
+++ b/http/pg-simulator/payments.http
@@ -8,11 +8,11 @@ Content-Type: application/json
   "cardType": "SAMSUNG",
   "cardNo": "1234-5678-9814-1451",
   "amount": "5000",
-  "callbackUrl": "http://localhost:8080/api/v1/examples/callback"
+  "callbackUrl": "http://localhost:8080/api/v1/orders/callback"
 }
 
 ### 결제 정보 확인
-GET {{pg-simulator}}/api/v1/payments/20250816:TR:9577c5
+GET {{pg-simulator}}/api/v1/payments/20250821:TR:af061d
 X-USER-ID: 135135
 
 ### 주문에 엮인 결제 정보 조회

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "loopers-java-spring-template"
 
 include(
     ":apps:commerce-api",
+    ":apps:pg-simulator",
     ":modules:jpa",
     ":modules:redis",
     ":supports:jackson",


### PR DESCRIPTION
## 📌 Summary
1. Resilience 추가하여 CurcuitBreaker, Retry 기능 구현. fallback 메서드 작성
2. 결제 대기, 결제 실패를 확인하기 위한 스케줄러 구현(재고 원복)
3. 결제 실패에 대한 대응 로직 구현

## 💬 Review Points
Resilience에 대해 학습하고 적용은 해봤지만 Retry, CurcuitBreaker라는 게 아직은 크게 와닿지는 않는 것 같습니다.
'결제의 경우 재시도, 자주 실패하면 api 못흐르게 해!'는 이해했지만 
1. 얼마나 재시도 해야 우리 서비스, 외부 모듈에 안정적일까?
2. 얼마나 실패해야 외부 모듈에 요청을 못보내게 막아야 할까?
이 두개가 가장 고민이 컸던 것 같습니다.

특히 '**돈'과 관련이 생겨버리면 함부로 예상할 수 없다는 점**. 이게 가장 걸립니다.

보통 이러한 '돈'과 관련된 로직에 대해 방어로직을 세울 때, 본인만의 기준이나 조심해야 한다는 점이 있으셨을지 궁금합니다.
(회사에서도 스케줄러로 외부 api 찔러서 상태 업데이트 하는 것들이 굉장히 많은데 도입하면 좋을 것 같아서 고려중입니다.)
## ✅ Checklist
- [v]  PG 연동 API는 RestTemplate 혹은 FeignClient 로 외부 시스템을 호출한다.
- [v]  응답 지연에 대해 타임아웃을 설정하고, 실패 시 적절한 예외 처리 로직을 구현한다.
- [v]  결제 요청에 대한 실패 응답에 대해 적절한 시스템 연동을 진행한다.
- [v]  콜백 방식 + **결제 상태 확인 API**를 활용해 적절하게 시스템과 결제정보를 연동한다.

### **🛡 Resilience 설계**

- [v]  서킷 브레이커 혹은 재시도 정책을 적용하여 장애 확산을 방지한다.
- [v]  외부 시스템 장애 시에도 내부 시스템은 **정상적으로 응답**하도록 보호한다.
- [v]  콜백이 오지 않더라도, 일정 주기 혹은 수동 API 호출로 상태를 복구할 수 있다.
- [v]  PG 에 대한 요청이 타임아웃에 의해 실패되더라도 해당 결제건에 대한 정보를 확인하여 정상적으로 시스템에 반영한다.