### PR TITLE
[volume-7] 이벤트로 프로세스 쪼개기

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/couponmember/CouponMemberService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/couponmember/CouponMemberService.java
@@ -32,4 +32,13 @@ public class CouponMemberService {
                 orElseThrow(() -> new CoreException(CommonErrorType.BAD_REQUEST, "쿠폰을 찾을 수 없습니다. couponId: " + couponId + ", memberId: " + memberId));
     }
 
+    /*
+     * 쿠폰 사용 취소
+     * */
+    public void cancelCouponUsage(Long memberId, Long couponId) {
+        CouponMember couponMember = couponMemberRepository.findByCouponIdAndMemberIdIsUsedWithLock(memberId, couponId).
+                orElseThrow(() -> new CoreException(CommonErrorType.BAD_REQUEST, "사용된 쿠폰을 찾을 수 없습니다. couponId: " + couponId + ", memberId: " + memberId));
+
+        couponMember.cancelCouponUsage();
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/orderItem/service/OrderItemService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orderItem/service/OrderItemService.java
@@ -25,4 +25,10 @@ public class OrderItemService {
         return orderItemRepository.findByOrdersId(orderId)
                 .orElseThrow(() -> new CoreException(CommonErrorType.NOT_FOUND, "주문 아이템을 찾을 수 없습니다. orderId: " + orderId));
     }
+
+    public List<OrderItem> findAllByOrdersId(Long ordersId) {
+        return orderItemRepository.findByOrdersId(ordersId)
+                .map(List::of)
+                .orElseThrow(() -> new CoreException(CommonErrorType.NOT_FOUND, "주문 아이템을 찾을 수 없습니다. orderId: " + ordersId));
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/facade/OrdersFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/facade/OrdersFacade.java
@@ -115,6 +115,7 @@ public class OrdersFacade {
         ));
 
         return OrdersRegisterInfoResult.of(
+                orders.getId(),
                 orders.getOrderStatus(),
                 LocalDateTime.from(orders.getCreatedAt()),
                 orders.getTotalPrice(),

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/facade/OrdersFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/facade/OrdersFacade.java
@@ -129,7 +129,8 @@ public class OrdersFacade {
                 command.getPaymentType(),
                 command.getCardType(),
                 command.getCardNo(),
-                payment.getId()
+                payment.getId(),
+                command.getCouponId()
         );
 
         // 주문 리스트 생성

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/facade/OrdersFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/facade/OrdersFacade.java
@@ -1,17 +1,12 @@
 package com.loopers.application.orders.facade;
 
 import com.loopers.application.coupon.CouponService;
-import com.loopers.application.couponmember.CouponMemberService;
 import com.loopers.application.member.service.MemberService;
 import com.loopers.application.orderItem.service.OrderItemService;
 import com.loopers.application.orders.command.PlaceOrderCommand;
 import com.loopers.application.orders.result.OrdersInfoResult;
 import com.loopers.application.orders.result.OrdersRegisterInfoResult;
 import com.loopers.application.orders.service.OrdersService;
-import com.loopers.application.payment.PaymentService;
-import com.loopers.application.payment.processor.PaymentProcessorRegistry;
-import com.loopers.application.product.service.ProductService;
-import com.loopers.application.stock.service.StockService;
 import com.loopers.domain.coupon.Coupon;
 import com.loopers.domain.member.Member;
 import com.loopers.domain.orderItem.OrderItem;
@@ -36,15 +31,10 @@ import java.util.List;
 public class OrdersFacade {
 
     private final OrdersService ordersService;
-    private final ProductService productService;
     private final OrderItemDomainService orderItemDomainService;
     private final OrderItemService orderItemsService;
-    private final StockService stockService;
     private final MemberService memberService;
     private final CouponService couponService;
-    private final CouponMemberService couponMemberService;
-    private final PaymentProcessorRegistry paymentProcessorRegistry;
-    private final PaymentService paymentService;
 
     private final ApplicationEventPublisher eventPublisher;
 
@@ -64,63 +54,85 @@ public class OrdersFacade {
     public OrdersRegisterInfoResult placeOrder(PlaceOrderCommand command) {
         // 주문 키 생성
         String orderKey = UUIDUtil.generateShortUUID();
+        log.info("[{}] 주문 프로세스 시작. command: {}", orderKey, command);
 
-        // 1. 사용자 조회
-        Member member = memberService.findMemberById(command.getMemberId());
+        try {
+            // 1. 사용자 조회
+            log.info("[{}] 사용자 조회 시작. memberId: {}", orderKey, command.getMemberId());
+            Member member = memberService.findMemberById(command.getMemberId());
+            log.info("[{}] 사용자 조회 완료. memberId: {}", orderKey, member.getId());
 
-        BigDecimal totalPrice = BigDecimal.ZERO;
-        int quantity = 0;
+            BigDecimal totalPrice = BigDecimal.ZERO;
+            int quantity = 0;
 
-        for (PlaceOrderCommand.Item item : command.getItems()) {
-            quantity += item.getQuantity();
-            totalPrice = totalPrice.add(item.getPrice().multiply(BigDecimal.valueOf(item.getQuantity())));
-        }
+            for (PlaceOrderCommand.Item item : command.getItems()) {
+                quantity += item.getQuantity();
+                totalPrice = totalPrice.add(item.getPrice().multiply(BigDecimal.valueOf(item.getQuantity())));
+            }
+            log.info("[{}] 총 주문 금액 계산 완료. totalPrice: {}, quantity: {}", orderKey, totalPrice, quantity);
 
-        // 쿠폰 할인 계산
-        BigDecimal finalPrice = totalPrice;
-        if (command.getCouponId() != null) {
-            Coupon coupon = couponService.getCouponId(command.getCouponId());
-            finalPrice = coupon.calculateDiscount(totalPrice);
-        }
+            // 쿠폰 할인 계산
+            BigDecimal finalPrice = totalPrice;
+            if (command.getCouponId() != null) {
+                log.info("[{}] 쿠폰 할인 적용 시작. couponId: {}", orderKey, command.getCouponId());
+                Coupon coupon = couponService.getCouponId(command.getCouponId());
+                finalPrice = coupon.calculateDiscount(totalPrice);
+                log.info("[{}] 쿠폰 할인 적용 완료. finalPrice: {}", orderKey, finalPrice);
+            }
 
-        // 주문 생성
-        Orders orders = ordersService.register(
-                member.getId(),
-                quantity,
-                finalPrice,
-                orderKey
-        );
-
-        // 주문 리스트 생성
-        List<OrderItem> orderItems = new ArrayList<>();
-        for (PlaceOrderCommand.Item item : command.getItems()) {
-            OrderItem orderItem = orderItemDomainService.createOrderItem(
-                    orders.getId(),
-                    item.getProductId(),
-                    item.getQuantity(),
-                    item.getPrice()
+            // 주문 생성
+            log.info("[{}] 주문 생성 시작. memberId: {}, quantity: {}, finalPrice: {}", orderKey, member.getId(), quantity, finalPrice);
+            Orders orders = ordersService.register(
+                    member.getId(),
+                    quantity,
+                    finalPrice,
+                    orderKey
             );
-            orderItems.add(orderItem);
+            log.info("[{}] 주문 생성 완료. orderId: {}", orderKey, orders.getId());
+
+            // 주문 리스트 생성
+            List<OrderItem> orderItems = new ArrayList<>();
+            for (PlaceOrderCommand.Item item : command.getItems()) {
+                OrderItem orderItem = orderItemDomainService.createOrderItem(
+                        orders.getId(),
+                        item.getProductId(),
+                        item.getQuantity(),
+                        item.getPrice()
+                );
+                orderItems.add(orderItem);
+            }
+            orderItemsService.register(orderItems);
+            log.info("[{}] 주문 아이템 생성 완료. count: {}", orderKey, orderItems.size());
+
+            // 이벤트 발행
+            OrdersCreatedEvent event = OrdersCreatedEvent.of(
+                    orders.getId(),
+                    orderKey,
+                    member.getId(),
+                    command.getCouponId(),
+                    command.getPaymentType(),
+                    command.getCardType(),
+                    command.getCardNo()
+            );
+            log.info("[{}] OrdersCreatedEvent 발행 시작. event: {}", orderKey, event);
+            eventPublisher.publishEvent(event);
+            log.info("[{}] OrdersCreatedEvent 발행 완료.", orderKey);
+
+
+            OrdersRegisterInfoResult result = OrdersRegisterInfoResult.of(
+                    orders.getId(),
+                    orders.getOrderStatus(),
+                    LocalDateTime.from(orders.getCreatedAt()),
+                    orders.getTotalPrice(),
+                    orders.getQuantity()
+            );
+            log.info("[{}] 주문 프로세스 성공. result: {}", orderKey, result);
+            return result;
+
+        } catch (Exception e) {
+            log.error("[{}] 주문 프로세스 실패. command: {}", orderKey, command, e);
+            throw e;
         }
-        orderItemsService.register(orderItems);
-
-        // 이벤트 발행
-        eventPublisher.publishEvent(OrdersCreatedEvent.of(
-                orders.getId(),
-                member.getId(),
-                command.getCouponId(),
-                command.getPaymentType(),
-                command.getCardType(),
-                command.getCardNo()
-        ));
-
-        return OrdersRegisterInfoResult.of(
-                orders.getId(),
-                orders.getOrderStatus(),
-                LocalDateTime.from(orders.getCreatedAt()),
-                orders.getTotalPrice(),
-                orders.getQuantity()
-        );
     }
 
     /*

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/listener/CouponEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/listener/CouponEventListener.java
@@ -7,6 +7,7 @@ import com.loopers.domain.couponmember.CouponMember;
 import com.loopers.domain.orders.event.CouponProcessedEvent;
 import com.loopers.domain.orders.event.OrdersCreatedEvent;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -16,6 +17,7 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class CouponEventListener {
 
@@ -28,15 +30,27 @@ public class CouponEventListener {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(OrdersCreatedEvent event) {
+        String orderKey = event.orderKey();
+        log.info("[{}] 쿠폰 처리 리스너 시작. event: {}", orderKey, event);
+
         try {
             if (event.couponId() != null) {
+                log.info("[{}] 쿠폰 사용 처리 시작. memberId: {}, couponId: {}", orderKey, event.memberId(), event.couponId());
                 CouponMember couponMember = couponMemberService.getCouponMemberById(event.memberId(), event.couponId());
                 couponMember.useCoupon();
+                log.info("[{}] 쿠폰 사용 처리 완료.", orderKey);
+            } else {
+                log.info("[{}] 사용된 쿠폰 없음.", orderKey);
             }
 
             // 다음 이벤트를 발행하여 체인을 이어갑니다.
-            eventPublisher.publishEvent(CouponProcessedEvent.from(event));
+            CouponProcessedEvent nextEvent = CouponProcessedEvent.from(event);
+            log.info("[{}] CouponProcessedEvent 발행 시작. event: {}", orderKey, nextEvent);
+            eventPublisher.publishEvent(nextEvent);
+            log.info("[{}] CouponProcessedEvent 발행 완료.", orderKey);
+
         } catch (Exception e) {
+            log.error("[{}] 쿠폰 처리 실패. event: {}", orderKey, event, e);
             orderFailService.markFailed(event.ordersId());
             throw e;
         }

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/listener/CouponEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/listener/CouponEventListener.java
@@ -1,0 +1,34 @@
+package com.loopers.application.orders.listener;
+
+import com.loopers.application.couponmember.CouponMemberService;
+import com.loopers.domain.couponmember.CouponMember;
+import com.loopers.domain.orders.event.CouponProcessedEvent;
+import com.loopers.domain.orders.event.OrdersCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class CouponEventListener {
+
+    private final CouponMemberService couponMemberService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Async
+    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(OrdersCreatedEvent event) {
+        if (event.couponId() != null) {
+            CouponMember couponMember = couponMemberService.getCouponMemberById(event.memberId(), event.couponId());
+            couponMember.useCoupon();
+        }
+
+        // 다음 이벤트를 발행하여 체인을 이어갑니다.
+        eventPublisher.publishEvent(CouponProcessedEvent.from(event));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/listener/CouponEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/listener/CouponEventListener.java
@@ -1,6 +1,8 @@
 package com.loopers.application.orders.listener;
 
 import com.loopers.application.couponmember.CouponMemberService;
+import com.loopers.application.orders.service.OrderFailService;
+import com.loopers.application.orders.service.OrdersService;
 import com.loopers.domain.couponmember.CouponMember;
 import com.loopers.domain.orders.event.CouponProcessedEvent;
 import com.loopers.domain.orders.event.OrdersCreatedEvent;
@@ -8,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -17,18 +20,25 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class CouponEventListener {
 
     private final CouponMemberService couponMemberService;
+    private final OrdersService ordersService;
+    private final OrderFailService orderFailService;
     private final ApplicationEventPublisher eventPublisher;
 
     @Async
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(OrdersCreatedEvent event) {
-        if (event.couponId() != null) {
-            CouponMember couponMember = couponMemberService.getCouponMemberById(event.memberId(), event.couponId());
-            couponMember.useCoupon();
-        }
+        try {
+            if (event.couponId() != null) {
+                CouponMember couponMember = couponMemberService.getCouponMemberById(event.memberId(), event.couponId());
+                couponMember.useCoupon();
+            }
 
-        // 다음 이벤트를 발행하여 체인을 이어갑니다.
-        eventPublisher.publishEvent(CouponProcessedEvent.from(event));
+            // 다음 이벤트를 발행하여 체인을 이어갑니다.
+            eventPublisher.publishEvent(CouponProcessedEvent.from(event));
+        } catch (Exception e) {
+            orderFailService.markFailed(event.ordersId());
+            throw e;
+        }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/listener/PaymentEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/listener/PaymentEventListener.java
@@ -1,0 +1,58 @@
+package com.loopers.application.orders.listener;
+
+import com.loopers.application.orders.service.OrdersService;
+import com.loopers.application.payment.PaymentContext;
+import com.loopers.application.payment.PaymentService;
+import com.loopers.application.payment.processor.PaymentProcessorRegistry;
+import com.loopers.domain.orders.Orders;
+import com.loopers.domain.orders.event.StockDecrementedEvent;
+import com.loopers.domain.payment.Payment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentEventListener {
+
+    private final OrdersService ordersService;
+    private final PaymentService paymentService;
+    private final PaymentProcessorRegistry paymentProcessorRegistry;
+
+    @Async
+    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(StockDecrementedEvent event) {
+        // 1. 주문 정보 조회
+        Orders orders = ordersService.findById(event.ordersId());
+
+        // 2. 결제 엔티티 생성 및 저장
+        Payment payment = paymentService.register(
+                orders.getId(),
+                orders.getOrderKey(),
+                event.paymentType(),
+                event.cardType(),
+                event.cardNo(),
+                orders.getTotalPrice(),
+                event.memberId()
+        );
+
+        // 3. 결제 프로세서에 넘길 컨텍스트 생성
+        PaymentContext paymentContext = PaymentContext.of(
+                orders.getOrderKey(),
+                event.memberId(),
+                orders.getTotalPrice(),
+                event.paymentType(),
+                event.cardType(),
+                event.cardNo(),
+                payment.getId(),
+                event.couponId()
+        );
+
+        // 4. 결제 타입에 맞는 프로세서로 결제 실행
+        paymentProcessorRegistry.get(event.paymentType()).processPayment(paymentContext);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/listener/PaymentEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/listener/PaymentEventListener.java
@@ -1,5 +1,6 @@
 package com.loopers.application.orders.listener;
 
+import com.loopers.application.orders.service.OrderFailService;
 import com.loopers.application.orders.service.OrdersService;
 import com.loopers.application.payment.PaymentContext;
 import com.loopers.application.payment.PaymentService;
@@ -10,6 +11,7 @@ import com.loopers.domain.payment.Payment;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -19,40 +21,47 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class PaymentEventListener {
 
     private final OrdersService ordersService;
+    private final OrderFailService orderFailService;
     private final PaymentService paymentService;
     private final PaymentProcessorRegistry paymentProcessorRegistry;
 
     @Async
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(StockDecrementedEvent event) {
-        // 1. 주문 정보 조회
-        Orders orders = ordersService.findById(event.ordersId());
+        try {
 
-        // 2. 결제 엔티티 생성 및 저장
-        Payment payment = paymentService.register(
-                orders.getId(),
-                orders.getOrderKey(),
-                event.paymentType(),
-                event.cardType(),
-                event.cardNo(),
-                orders.getTotalPrice(),
-                event.memberId()
-        );
+            // 1. 주문 정보 조회
+            Orders orders = ordersService.findById(event.ordersId());
 
-        // 3. 결제 프로세서에 넘길 컨텍스트 생성
-        PaymentContext paymentContext = PaymentContext.of(
-                orders.getOrderKey(),
-                event.memberId(),
-                orders.getTotalPrice(),
-                event.paymentType(),
-                event.cardType(),
-                event.cardNo(),
-                payment.getId(),
-                event.couponId()
-        );
+            // 2. 결제 엔티티 생성 및 저장
+            Payment payment = paymentService.register(
+                    orders.getId(),
+                    orders.getOrderKey(),
+                    event.paymentType(),
+                    event.cardType(),
+                    event.cardNo(),
+                    orders.getTotalPrice(),
+                    event.memberId()
+            );
 
-        // 4. 결제 타입에 맞는 프로세서로 결제 실행
-        paymentProcessorRegistry.get(event.paymentType()).processPayment(paymentContext);
+            // 3. 결제 프로세서에 넘길 컨텍스트 생성
+            PaymentContext paymentContext = PaymentContext.of(
+                    orders.getOrderKey(),
+                    event.memberId(),
+                    orders.getTotalPrice(),
+                    event.paymentType(),
+                    event.cardType(),
+                    event.cardNo(),
+                    payment.getId(),
+                    event.couponId()
+            );
+
+            // 4. 결제 타입에 맞는 프로세서로 결제 실행
+            paymentProcessorRegistry.get(event.paymentType()).processPayment(paymentContext);
+        } catch (Exception e) {
+            orderFailService.markFailed(event.ordersId());
+            throw e;
+        }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/listener/PaymentEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/listener/PaymentEventListener.java
@@ -9,6 +9,7 @@ import com.loopers.domain.orders.Orders;
 import com.loopers.domain.orders.event.StockDecrementedEvent;
 import com.loopers.domain.payment.Payment;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -17,6 +18,7 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class PaymentEventListener {
 
@@ -29,12 +31,18 @@ public class PaymentEventListener {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(StockDecrementedEvent event) {
+        String orderKey = event.orderKey();
+        log.info("[{}] 결제 처리 리스너 시작. event: {}", orderKey, event);
+
         try {
 
             // 1. 주문 정보 조회
+            log.info("[{}] 주문 정보 조회 시작. orderId: {}", orderKey, event.ordersId());
             Orders orders = ordersService.findById(event.ordersId());
+            log.info("[{}] 주문 정보 조회 완료. orderStatus: {}", orderKey, orders.getOrderStatus());
 
             // 2. 결제 엔티티 생성 및 저장
+            log.info("[{}] 결제 정보 저장 시작.", orderKey);
             Payment payment = paymentService.register(
                     orders.getId(),
                     orders.getOrderKey(),
@@ -44,6 +52,8 @@ public class PaymentEventListener {
                     orders.getTotalPrice(),
                     event.memberId()
             );
+            log.info("[{}] 결제 정보 저장 완료. paymentId: {}", orderKey, payment.getId());
+
 
             // 3. 결제 프로세서에 넘길 컨텍스트 생성
             PaymentContext paymentContext = PaymentContext.of(
@@ -58,8 +68,13 @@ public class PaymentEventListener {
             );
 
             // 4. 결제 타입에 맞는 프로세서로 결제 실행
+            log.info("[{}] 외부 결제 프로세서 호출 시작. context: {}", orderKey, paymentContext);
             paymentProcessorRegistry.get(event.paymentType()).processPayment(paymentContext);
+            log.info("[{}] 외부 결제 프로세서 호출 완료.", orderKey);
+            log.info("[{}] 결제 처리 리스너 성공.", orderKey);
+
         } catch (Exception e) {
+            log.error("[{}] 결제 처리 실패. event: {}", orderKey, event, e);
             orderFailService.markFailed(event.ordersId());
             throw e;
         }

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/listener/StockEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/listener/StockEventListener.java
@@ -1,0 +1,41 @@
+package com.loopers.application.orders.listener;
+
+import com.loopers.application.orderItem.service.OrderItemService;
+import com.loopers.application.stock.service.StockService;
+import com.loopers.domain.orderItem.OrderItem;
+import com.loopers.domain.orders.event.CouponProcessedEvent;
+import com.loopers.domain.orders.event.StockDecrementedEvent;
+import com.loopers.domain.stock.Stock;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class StockEventListener {
+
+    private final StockService stockService;
+    private final OrderItemService orderItemService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Async
+    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(CouponProcessedEvent event) {
+        List<OrderItem> orderItems = orderItemService.findAllByOrdersId(event.ordersId());
+
+        for (OrderItem item : orderItems) {
+            Stock stock = stockService.findStockByProductIdWithLock(item.getProductId());
+
+            stock.decreaseQuantity(item.getQuantity());
+        }
+            
+        eventPublisher.publishEvent(StockDecrementedEvent.from(event));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/listener/StockEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/listener/StockEventListener.java
@@ -9,6 +9,7 @@ import com.loopers.domain.orders.event.CouponProcessedEvent;
 import com.loopers.domain.orders.event.StockDecrementedEvent;
 import com.loopers.domain.stock.Stock;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -20,6 +21,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 import java.util.List;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class StockEventListener {
 
@@ -33,17 +35,28 @@ public class StockEventListener {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(CouponProcessedEvent event) {
+        String orderKey = event.orderKey();
+        log.info("[{}] 재고 차감 리스너 시작. event: {}", orderKey, event);
+
         try {
+            log.info("[{}] 주문 아이템 조회 시작. orderId: {}", orderKey, event.ordersId());
             List<OrderItem> orderItems = orderItemService.findAllByOrdersId(event.ordersId());
+            log.info("[{}] 주문 아이템 조회 완료. count: {}", orderKey, orderItems.size());
 
             for (OrderItem item : orderItems) {
+                log.info("[{}] 상품 재고 차감 시도. productId: {}, quantity: {}", orderKey, item.getProductId(), item.getQuantity());
                 Stock stock = stockService.findStockByProductIdWithLock(item.getProductId());
-
                 stock.decreaseQuantity(item.getQuantity());
+                log.info("[{}] 상품 재고 차감 완료. productId: {}", orderKey, item.getProductId());
             }
 
-            eventPublisher.publishEvent(StockDecrementedEvent.from(event));
+            StockDecrementedEvent nextEvent = StockDecrementedEvent.from(event);
+            log.info("[{}] StockDecrementedEvent 발행 시작. event: {}", orderKey, nextEvent);
+            eventPublisher.publishEvent(nextEvent);
+            log.info("[{}] StockDecrementedEvent 발행 완료.", orderKey);
+
         } catch (Exception e) {
+            log.error("[{}] 재고 차감 실패. event: {}", orderKey, event, e);
             orderFailService.markFailed(event.ordersId());
             throw e;
         }

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/result/OrdersRegisterInfoResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/result/OrdersRegisterInfoResult.java
@@ -15,6 +15,8 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrdersRegisterInfoResult {
 
+    private Long ordersId;
+
     private OrderStatus orderStatus;
 
     private PaymentStatus paymentStatus;
@@ -25,7 +27,8 @@ public class OrdersRegisterInfoResult {
 
     private int totalCount;
 
-    private OrdersRegisterInfoResult(OrderStatus orderStatus, LocalDateTime orderDate, BigDecimal totalPrice, int totalCount) {
+    private OrdersRegisterInfoResult(Long ordersId, OrderStatus orderStatus, LocalDateTime orderDate, BigDecimal totalPrice, int totalCount) {
+        this.ordersId = ordersId;
         this.orderStatus = orderStatus;
         this.paymentStatus = PaymentStatus.PENDING;
         this.orderDate = orderDate;
@@ -33,13 +36,16 @@ public class OrdersRegisterInfoResult {
         this.totalCount = totalCount;
     }
 
-    public static OrdersRegisterInfoResult of(OrderStatus orderStatus, LocalDateTime orderDate, BigDecimal totalPrice, int totalCount) {
-        validate(orderStatus, orderDate, totalPrice, totalCount);
+    public static OrdersRegisterInfoResult of(Long ordersId, OrderStatus orderStatus, LocalDateTime orderDate, BigDecimal totalPrice, int totalCount) {
+        validate(ordersId, orderStatus, orderDate, totalPrice, totalCount);
 
-        return new OrdersRegisterInfoResult(orderStatus, orderDate, totalPrice, totalCount);
+        return new OrdersRegisterInfoResult(ordersId, orderStatus, orderDate, totalPrice, totalCount);
     }
 
-    private static void validate(OrderStatus orderStatus, LocalDateTime orderDate, BigDecimal totalPrice, int totalCount) {
+    private static void validate(Long ordersId, OrderStatus orderStatus, LocalDateTime orderDate, BigDecimal totalPrice, int totalCount) {
+        if (ordersId == null || ordersId <= 0) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 주문 ID가 필요합니다.");
+        }
         if (orderStatus == null) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "주문 상태는 필수입니다.");
         }

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/result/OrdersRegisterInfoResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/result/OrdersRegisterInfoResult.java
@@ -1,6 +1,7 @@
 package com.loopers.application.orders.result;
 
 import com.loopers.domain.orders.OrderStatus;
+import com.loopers.domain.payment.PaymentStatus;
 import com.loopers.support.error.CommonErrorType;
 import com.loopers.support.error.CoreException;
 import lombok.AccessLevel;
@@ -16,7 +17,7 @@ public class OrdersRegisterInfoResult {
 
     private OrderStatus orderStatus;
 
-    private String paymentStatus;
+    private PaymentStatus paymentStatus;
 
     private LocalDateTime orderDate;
 
@@ -24,26 +25,23 @@ public class OrdersRegisterInfoResult {
 
     private int totalCount;
 
-    private OrdersRegisterInfoResult(OrderStatus orderStatus, String paymentStatus, LocalDateTime orderDate, BigDecimal totalPrice, int totalCount) {
+    private OrdersRegisterInfoResult(OrderStatus orderStatus, LocalDateTime orderDate, BigDecimal totalPrice, int totalCount) {
         this.orderStatus = orderStatus;
-        this.paymentStatus = paymentStatus;
+        this.paymentStatus = PaymentStatus.PENDING;
         this.orderDate = orderDate;
         this.totalPrice = totalPrice;
         this.totalCount = totalCount;
     }
 
-    public static OrdersRegisterInfoResult of(OrderStatus orderStatus, String paymentStatus, LocalDateTime orderDate, BigDecimal totalPrice, int totalCount) {
-        validate(orderStatus, paymentStatus, orderDate, totalPrice, totalCount);
+    public static OrdersRegisterInfoResult of(OrderStatus orderStatus, LocalDateTime orderDate, BigDecimal totalPrice, int totalCount) {
+        validate(orderStatus, orderDate, totalPrice, totalCount);
 
-        return new OrdersRegisterInfoResult(orderStatus, paymentStatus, orderDate, totalPrice, totalCount);
+        return new OrdersRegisterInfoResult(orderStatus, orderDate, totalPrice, totalCount);
     }
 
-    private static void validate(OrderStatus orderStatus, String paymentStatus, LocalDateTime orderDate, BigDecimal totalPrice, int totalCount) {
+    private static void validate(OrderStatus orderStatus, LocalDateTime orderDate, BigDecimal totalPrice, int totalCount) {
         if (orderStatus == null) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "주문 상태는 필수입니다.");
-        }
-        if (paymentStatus == null || paymentStatus.isEmpty()) {
-            throw new CoreException(CommonErrorType.BAD_REQUEST, "결제 상태는 필수입니다.");
         }
         if (orderDate == null) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "주문 날짜는 필수입니다.");

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/service/OrderFailService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/service/OrderFailService.java
@@ -1,0 +1,19 @@
+package com.loopers.application.orders.service;
+
+import com.loopers.domain.orders.Orders;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderFailService {
+    private final OrdersService ordersService;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markFailed(Long ordersId) {
+        Orders orders = ordersService.findById(ordersId);
+        orders.updateOrdersFailed();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/orders/service/OrdersService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/orders/service/OrdersService.java
@@ -21,10 +21,10 @@ public class OrdersService {
     /*
      * 주문 생성
      * */
-    public Orders register(Long memberId, int quantity, BigDecimal totalPrice, Long couponMemberId, boolean couponUsed, String orderKey) {
+    public Orders register(Long memberId, int quantity, BigDecimal totalPrice, String orderKey) {
         Orders orders = null;
 
-        orders = Orders.create(memberId, quantity, totalPrice, couponMemberId, couponUsed, orderKey);
+        orders = Orders.create(memberId, quantity, totalPrice, orderKey);
         return ordersRepository.register(orders);
     }
 
@@ -37,5 +37,23 @@ public class OrdersService {
         }
 
         return ordersRepository.findAllByMemberId(memberId);
+    }
+
+    public Orders findById(Long ordersId) {
+        if (ordersId == null || ordersId <= 0) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 주문 ID가 필요합니다.");
+        }
+
+        return ordersRepository.findById(ordersId)
+                .orElseThrow(() -> new CoreException(CommonErrorType.NOT_FOUND, "주문을 찾을 수 없습니다. ordersId=" + ordersId));
+    }
+
+    public Orders findByOrderKeyWithLock(String orderKey) {
+        if (orderKey == null || orderKey.isBlank()) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 주문 키가 필요합니다.");
+        }
+
+        return ordersRepository.findByOrderKeyWithLock(orderKey)
+                .orElseThrow(() -> new CoreException(CommonErrorType.NOT_FOUND, "주문을 찾을 수 없습니다. orderKey=" + orderKey));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentContext.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentContext.java
@@ -14,7 +14,8 @@ public record PaymentContext(
         PaymentType paymentType,
         CardType cardType,
         String cardNo,
-        Long paymentId
+        Long paymentId,
+        Long couponId
 ) {
 
     public static PaymentContext of(String orderKey,
@@ -23,7 +24,8 @@ public record PaymentContext(
                                     PaymentType paymentType,
                                     CardType cardType,
                                     String cardNo,
-                                    Long paymentId) {
+                                    Long paymentId,
+                                    Long couponId) {
         if (orderKey == null || orderKey.isBlank()) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "주문 키가 비어 있습니다.");
         }
@@ -50,7 +52,7 @@ public record PaymentContext(
         if (paymentId != null && paymentId <= 0) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "유효하지 않은 결제 ID입니다.");
         }
-        return new PaymentContext(orderKey, memberId, amount, paymentType, cardType, cardNo, paymentId);
+        return new PaymentContext(orderKey, memberId, amount, paymentType, cardType, cardNo, paymentId, couponId);
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentGatewayPort.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentGatewayPort.java
@@ -3,14 +3,12 @@ package com.loopers.application.payment;
 import com.loopers.domain.payment.CardType;
 import com.loopers.infrastructure.payment.PgPaymentResponse;
 
-import java.math.BigDecimal;
-
 public interface PaymentGatewayPort {
 
     PgPaymentResponse requestPayment(String orderKey,
                                      CardType cardType,
                                      String cardNo,
-                                     BigDecimal amount,
+                                     Long amount,
                                      Long memberId);
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/processor/CardPaymentProcessor.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/processor/CardPaymentProcessor.java
@@ -1,5 +1,6 @@
 package com.loopers.application.payment.processor;
 
+import com.loopers.application.couponmember.CouponMemberService;
 import com.loopers.application.payment.PaymentContext;
 import com.loopers.application.payment.PaymentGatewayPort;
 import com.loopers.application.payment.PaymentService;
@@ -21,6 +22,7 @@ public class CardPaymentProcessor implements PaymentProcessor {
 
     private final PaymentGatewayPort paymentGatewayPort;
     private final PaymentService paymentService;
+    private final CouponMemberService couponMemberService;
 
     @Override
     public PaymentType supports() {
@@ -40,12 +42,17 @@ public class CardPaymentProcessor implements PaymentProcessor {
         Payment payment = paymentService.findById(paymentContext.paymentId());
 
         // FAIL이 떨어지는 경우
-        if (pgPaymentResponse != null && !pgPaymentResponse.meta().result().equals("SUCCESS")) {
+        if (pgPaymentResponse != null && !"SUCCESS".equals(pgPaymentResponse.meta().result())) {
             log.error("PG 결제 실패 | orderKey={}, memberId={}, error={}, message={}",
                     paymentContext.orderKey(), paymentContext.memberId(), pgPaymentResponse.data().reason(), pgPaymentResponse.meta().message());
 
             // 실패 상태 + 사유 업데이트
             payment.updateStatus(PaymentStatus.FAILED, pgPaymentResponse.meta().message());
+
+            // 쿠폰이 있다면 쿠폰 사용 취소해야함.
+            if (paymentContext.couponId() != null) {
+                couponMemberService.cancelCouponUsage(paymentContext.memberId(), paymentContext.couponId());
+            }
 
             return PaymentResult.of(
                     pgPaymentResponse.meta().result(),

--- a/apps/commerce-api/src/main/java/com/loopers/application/productlike/listener/ProductLikeEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/productlike/listener/ProductLikeEventListener.java
@@ -1,0 +1,34 @@
+package com.loopers.application.productlike.listener;
+
+import com.loopers.application.product.service.ProductService;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.productlike.event.ProductLikedEvent;
+import com.loopers.domain.productlike.event.ProductUnlikedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ProductLikeEventListener {
+
+    private final ProductService productService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleLike(ProductLikedEvent event) {
+        Product product = productService.findProductById(event.productId());
+
+        product.increaseLikeCount();
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleUnlike(ProductUnlikedEvent event) {
+        Product product = productService.findProductById(event.productId());
+
+        product.decreaseLikeCount();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/productlike/listener/ProductLikeEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/productlike/listener/ProductLikeEventListener.java
@@ -5,6 +5,7 @@ import com.loopers.domain.product.Product;
 import com.loopers.domain.productlike.event.ProductLikedEvent;
 import com.loopers.domain.productlike.event.ProductUnlikedEvent;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -12,6 +13,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class ProductLikeEventListener {
 
     private final ProductService productService;
@@ -19,16 +21,28 @@ public class ProductLikeEventListener {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleLike(ProductLikedEvent event) {
-        Product product = productService.findProductById(event.productId());
+        try {
+            log.info("좋아요 이벤트 리스너 실행 - productId: {}, memberId: {}", event.productId(), event.memberId());
+            Product product = productService.findProductById(event.productId());
 
-        product.increaseLikeCount();
+            product.increaseLikeCount();
+            log.info("좋아요 이벤트 리스너 완료 - productId: {}, newLikeCount: {}", event.productId(), product.getLikeCount());
+        } catch (Exception e) {
+            log.error("좋아요 이벤트 리스너 처리 중 오류 발생 - productId: {}, memberId: {}", event.productId(), event.memberId(), e);
+        }
     }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleUnlike(ProductUnlikedEvent event) {
-        Product product = productService.findProductById(event.productId());
+        try {
+            log.info("좋아요 취소 이벤트 리스너 실행 - productId: {}, memberId: {}", event.productId(), event.memberId());
+            Product product = productService.findProductById(event.productId());
 
-        product.decreaseLikeCount();
+            product.decreaseLikeCount();
+            log.info("좋아요 취소 이벤트 리스너 완료 - productId: {}, newLikeCount: {}", event.productId(), product.getLikeCount());
+        } catch (Exception e) {
+            log.error("좋아요 취소 이벤트 리스너 처리 중 오류 발생 - productId: {}, memberId: {}", event.productId(), event.memberId(), e);
+        }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/couponmember/CouponMember.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/couponmember/CouponMember.java
@@ -104,6 +104,14 @@ public class CouponMember extends BaseEntity {
         this.usedAt = LocalDateTime.now();
     }
 
+    public void cancelCouponUsage() {
+        if (this.status != CouponStatus.USED) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "사용된 쿠폰이 아닙니다.");
+        }
+        this.status = CouponStatus.ACTIVE;
+        this.usedAt = null;
+    }
+
     public void checkCouponAvailable(Coupon coupon) {
         if (this.status != CouponStatus.ACTIVE) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "쿠폰이 활성화 상태가 아닙니다.");

--- a/apps/commerce-api/src/main/java/com/loopers/domain/couponmember/CouponMemberRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/couponmember/CouponMemberRepository.java
@@ -10,4 +10,6 @@ public interface CouponMemberRepository {
     CouponMember save(CouponMember couponMember);
 
     Optional<CouponMember> findByCouponIdAndMemberId(Long couponId, Long memberId);
+
+    Optional<CouponMember> findByCouponIdAndMemberIdIsUsedWithLock(Long memberId, Long couponId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderStatus.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrderStatus.java
@@ -6,9 +6,11 @@ import lombok.Getter;
 public enum OrderStatus {
     PENDING("주문 대기"),
     PROCESSING("주문 처리 중"),
+    CONFIRMED("주문 확정"),
     SHIPPED("배송 중"),
     DELIVERED("배송 완료"),
-    CANCELED("주문 취소");
+    CANCELED("주문 취소"),
+    FAILED("주문 실패");
 
     private final String description;
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/Orders.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/Orders.java
@@ -3,9 +3,7 @@ package com.loopers.domain.orders;
 import com.loopers.domain.BaseEntity;
 import com.loopers.support.error.CommonErrorType;
 import com.loopers.support.error.CoreException;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 
 import java.math.BigDecimal;
 
@@ -17,6 +15,7 @@ public class Orders extends BaseEntity {
     private Long memberId;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus;
 
     @Column(nullable = false)
@@ -34,16 +33,15 @@ public class Orders extends BaseEntity {
     protected Orders() {
     }
 
-    private Orders(Long memberId, int quantity, BigDecimal totalPrice, Long couponMemberId, String orderKey) {
+    private Orders(Long memberId, int quantity, BigDecimal totalPrice, String orderKey) {
         this.memberId = memberId;
         this.orderStatus = OrderStatus.PENDING;
         this.quantity = quantity;
         this.totalPrice = totalPrice;
-        this.couponMemberId = couponMemberId;
         this.orderKey = orderKey;
     }
 
-    public static Orders create(Long memberId, int quantity, BigDecimal totalPrice, Long couponMemberId, boolean couponUsed, String orderKey) {
+    public static Orders create(Long memberId, int quantity, BigDecimal totalPrice, String orderKey) {
         if (memberId == null || memberId <= 0) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 회원 ID가 필요합니다.");
         }
@@ -53,14 +51,11 @@ public class Orders extends BaseEntity {
         if (totalPrice == null || totalPrice.compareTo(BigDecimal.ZERO) <= 0) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "총 가격은 0 이상이어야 합니다.");
         }
-        if (couponUsed && (couponMemberId == null || couponMemberId <= 0)) {
-            throw new CoreException(CommonErrorType.BAD_REQUEST, "쿠폰 사용 시 유효한 쿠폰 회원 ID가 필요합니다.");
-        }
         if (orderKey == null || orderKey.isBlank()) {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 주문 키가 필요합니다.");
         }
 
-        return new Orders(memberId, quantity, totalPrice, couponMemberId, orderKey);
+        return new Orders(memberId, quantity, totalPrice, orderKey);
     }
 
     public Long getMemberId() {
@@ -85,5 +80,13 @@ public class Orders extends BaseEntity {
 
     public String getOrderKey() {
         return orderKey;
+    }
+
+    public void confirm() {
+        this.orderStatus = OrderStatus.CONFIRMED;
+    }
+
+    public void fail() {
+        this.orderStatus = OrderStatus.FAILED;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/Orders.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/Orders.java
@@ -89,4 +89,8 @@ public class Orders extends BaseEntity {
     public void fail() {
         this.orderStatus = OrderStatus.FAILED;
     }
+
+    public void updateOrdersFailed() {
+        this.orderStatus = OrderStatus.FAILED;
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrdersRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/OrdersRepository.java
@@ -1,10 +1,15 @@
 package com.loopers.domain.orders;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface OrdersRepository {
 
     Orders register(Orders orders);
 
     List<Orders> findAllByMemberId(Long memberId);
+
+    Optional<Orders> findById(Long ordersId);
+
+    Optional<Orders> findByOrderKeyWithLock(String orderKey);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/event/CouponProcessedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/event/CouponProcessedEvent.java
@@ -5,6 +5,7 @@ import com.loopers.domain.payment.PaymentType;
 
 public record CouponProcessedEvent(
         Long ordersId,
+        String orderKey,
         Long memberId,
         Long couponId,
         PaymentType paymentType,
@@ -12,6 +13,6 @@ public record CouponProcessedEvent(
         String cardNo) {
 
     public static CouponProcessedEvent from(OrdersCreatedEvent event) {
-        return new CouponProcessedEvent(event.ordersId(), event.memberId(), event.couponId(), event.paymentType(), event.cardType(), event.cardNo());
+        return new CouponProcessedEvent(event.ordersId(), event.orderKey(), event.memberId(), event.couponId(), event.paymentType(), event.cardType(), event.cardNo());
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/event/CouponProcessedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/event/CouponProcessedEvent.java
@@ -1,0 +1,17 @@
+package com.loopers.domain.orders.event;
+
+import com.loopers.domain.payment.CardType;
+import com.loopers.domain.payment.PaymentType;
+
+public record CouponProcessedEvent(
+        Long ordersId,
+        Long memberId,
+        Long couponId,
+        PaymentType paymentType,
+        CardType cardType,
+        String cardNo) {
+
+    public static CouponProcessedEvent from(OrdersCreatedEvent event) {
+        return new CouponProcessedEvent(event.ordersId(), event.memberId(), event.couponId(), event.paymentType(), event.cardType(), event.cardNo());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/event/OrdersCreatedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/event/OrdersCreatedEvent.java
@@ -5,13 +5,14 @@ import com.loopers.domain.payment.PaymentType;
 
 public record OrdersCreatedEvent
         (Long ordersId,
+         String orderKey,
          Long memberId,
          Long couponId,
          PaymentType paymentType,
          CardType cardType,
          String cardNo) {
 
-    public static OrdersCreatedEvent of(Long ordersId, Long memberId, Long couponId, PaymentType paymentType, CardType cardType, String cardNo) {
-        return new OrdersCreatedEvent(ordersId, memberId, couponId, paymentType, cardType, cardNo);
+    public static OrdersCreatedEvent of(Long ordersId, String orderKey, Long memberId, Long couponId, PaymentType paymentType, CardType cardType, String cardNo) {
+        return new OrdersCreatedEvent(ordersId, orderKey, memberId, couponId, paymentType, cardType, cardNo);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/event/OrdersCreatedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/event/OrdersCreatedEvent.java
@@ -1,0 +1,17 @@
+package com.loopers.domain.orders.event;
+
+import com.loopers.domain.payment.CardType;
+import com.loopers.domain.payment.PaymentType;
+
+public record OrdersCreatedEvent
+        (Long ordersId,
+         Long memberId,
+         Long couponId,
+         PaymentType paymentType,
+         CardType cardType,
+         String cardNo) {
+
+    public static OrdersCreatedEvent of(Long ordersId, Long memberId, Long couponId, PaymentType paymentType, CardType cardType, String cardNo) {
+        return new OrdersCreatedEvent(ordersId, memberId, couponId, paymentType, cardType, cardNo);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/event/StockDecrementedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/event/StockDecrementedEvent.java
@@ -1,0 +1,17 @@
+package com.loopers.domain.orders.event;
+
+import com.loopers.domain.payment.CardType;
+import com.loopers.domain.payment.PaymentType;
+
+public record StockDecrementedEvent(
+        Long ordersId,
+        Long memberId,
+        Long couponId,
+        PaymentType paymentType,
+        CardType cardType,
+        String cardNo) {
+
+    public static StockDecrementedEvent from(CouponProcessedEvent event) {
+        return new StockDecrementedEvent(event.ordersId(), event.memberId(), event.couponId(), event.paymentType(), event.cardType(), event.cardNo());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/orders/event/StockDecrementedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/orders/event/StockDecrementedEvent.java
@@ -5,6 +5,7 @@ import com.loopers.domain.payment.PaymentType;
 
 public record StockDecrementedEvent(
         Long ordersId,
+        String orderKey,
         Long memberId,
         Long couponId,
         PaymentType paymentType,
@@ -12,6 +13,6 @@ public record StockDecrementedEvent(
         String cardNo) {
 
     public static StockDecrementedEvent from(CouponProcessedEvent event) {
-        return new StockDecrementedEvent(event.ordersId(), event.memberId(), event.couponId(), event.paymentType(), event.cardType(), event.cardNo());
+        return new StockDecrementedEvent(event.ordersId(), event.orderKey(), event.memberId(), event.couponId(), event.paymentType(), event.cardType(), event.cardNo());
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/productlike/event/ProductLikedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/productlike/event/ProductLikedEvent.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.productlike.event;
+
+public record ProductLikedEvent(Long productId, Long memberId) {
+    public static ProductLikedEvent of(Long productId, Long memberId) {
+        return new ProductLikedEvent(productId, memberId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/productlike/event/ProductUnlikedEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/productlike/event/ProductUnlikedEvent.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.productlike.event;
+
+public record ProductUnlikedEvent(Long productId, Long memberId) {
+    public static ProductUnlikedEvent of(Long productId, Long memberId) {
+        return new ProductUnlikedEvent(productId, memberId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/couponmember/CounponMemberRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/couponmember/CounponMemberRepositoryImpl.java
@@ -28,4 +28,9 @@ public class CounponMemberRepositoryImpl implements CouponMemberRepository {
     public Optional<CouponMember> findByCouponIdAndMemberId(Long couponId, Long memberId) {
         return couponMemberJpaRepository.findByCouponIdAndMemberIdIsActive(couponId, memberId);
     }
+
+    @Override
+    public Optional<CouponMember> findByCouponIdAndMemberIdIsUsedWithLock(Long memberId, Long couponId) {
+        return couponMemberJpaRepository.findByCouponIdAndMemberIdIsUsedWithLock(couponId, memberId);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/couponmember/CouponMemberJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/couponmember/CouponMemberJpaRepository.java
@@ -17,4 +17,8 @@ public interface CouponMemberJpaRepository extends JpaRepository<CouponMember, L
     @Query("SELECT cm FROM CouponMember cm WHERE cm.couponId = :couponId AND cm.memberId = :memberId AND cm.status = 'ACTIVE'")
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<CouponMember> findByCouponIdAndMemberIdIsActive(Long couponId, Long memberId);
+
+    @Query("SELECT cm FROM CouponMember cm WHERE cm.couponId = :couponId AND cm.memberId = :memberId AND cm.status = 'USED'")
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<CouponMember> findByCouponIdAndMemberIdIsUsedWithLock(Long couponId, Long memberId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/orders/OrdersJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/orders/OrdersJpaRepository.java
@@ -2,9 +2,14 @@ package com.loopers.infrastructure.orders;
 
 import com.loopers.domain.orders.Orders;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface OrdersJpaRepository extends JpaRepository<Orders, Long> {
     List<Orders> findAllByMemberId(Long memberId);
+
+    @Query("SELECT o FROM Orders o WHERE o.orderKey = :orderKey")
+    Optional<Orders> findByOrderKey(String orderKey);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/orders/OrdersRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/orders/OrdersRepositoryImpl.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -25,5 +26,21 @@ public class OrdersRepositoryImpl implements OrdersRepository {
             throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 회원 ID가 필요합니다.");
         }
         return ordersJpaRepository.findAllByMemberId(memberId);
+    }
+
+    @Override
+    public Optional<Orders> findById(Long ordersId) {
+        if (ordersId == null || ordersId <= 0) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 주문 ID가 필요합니다.");
+        }
+        return ordersJpaRepository.findById(ordersId);
+    }
+
+    @Override
+    public Optional<Orders> findByOrderKeyWithLock(String orderKey) {
+        if (orderKey == null || orderKey.isBlank()) {
+            throw new CoreException(CommonErrorType.BAD_REQUEST, "유효한 주문 키가 필요합니다.");
+        }
+        return ordersJpaRepository.findByOrderKey(orderKey);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentGatewayRestPort.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentGatewayRestPort.java
@@ -11,8 +11,6 @@ import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
-import java.math.BigDecimal;
-
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -45,7 +43,7 @@ public class PaymentGatewayRestPort implements PaymentGatewayPort {
         return response.getBody();
     }
 
-    private PgPaymentResponse paymentFallback(String orderKey, CardType cardType, String cardNo, BigDecimal amount,
+    private PgPaymentResponse paymentFallback(String orderKey, CardType cardType, String cardNo, Long amount,
                                               Long memberId, Throwable t) {
         if (t instanceof io.github.resilience4j.circuitbreaker.CallNotPermittedException) {
             log.error("CurcuitBreaker 열림 : {}", t.getMessage());

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentGatewayRestPort.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentGatewayRestPort.java
@@ -27,7 +27,7 @@ public class PaymentGatewayRestPort implements PaymentGatewayPort {
     public PgPaymentResponse requestPayment(String orderKey,
                                             CardType cardType,
                                             String cardNo,
-                                            BigDecimal amount,
+                                            Long amount,
                                             Long memberId) {
 
         HttpHeaders headers = new HttpHeaders();

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRequest.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRequest.java
@@ -2,19 +2,17 @@ package com.loopers.infrastructure.payment;
 
 import com.loopers.domain.payment.CardType;
 
-import java.math.BigDecimal;
-
 public record PaymentRequest(
         String orderId,
         CardType cardType,
         String cardNo,
-        String amount,
+        Long amount,
         String callbackUrl
 ) {
 
     private static final String CALLBACK_URL = "http://localhost:8080/api/v1/payments/callback";
 
-    public static PaymentRequest of(String orderId, CardType cardType, String cardNo, BigDecimal amount) {
-        return new PaymentRequest(orderId, cardType, cardNo, amount.toPlainString(), CALLBACK_URL);
+    public static PaymentRequest of(String orderId, CardType cardType, String cardNo, Long amount) {
+        return new PaymentRequest(orderId, cardType, cardNo, amount, CALLBACK_URL);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/payment/PaymentV1Controller.java
@@ -20,7 +20,7 @@ public class PaymentV1Controller {
      * 결제 콜백 API
      * */
     @PostMapping("/callback")
-    public String paymentCallback(@RequestBody PaymentCallbackDTO paymentCallbackDTO) {
+    public void paymentCallback(@RequestBody PaymentCallbackDTO paymentCallbackDTO) {
         // 트랜잭션키로 결제 정보 조회
         paymentFacade.processCallbackPayment(
                 new PaymentCallbackCommand(
@@ -29,7 +29,13 @@ public class PaymentV1Controller {
                 )
         );
 
-        return "Payment callback processed successfully.";
+        // 외부 데이터플랫폼으로 결과 전송(?)
+        // 솔직히 이 부분 잘 이해가 되지 않습니다. 흑
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/productlike/ProductLikeV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/productlike/ProductLikeV1Controller.java
@@ -23,7 +23,9 @@ public class ProductLikeV1Controller {
     @PostMapping
     public ApiResponse<ProductLikeResponseDto> registerProductLike(@RequestBody ProductLikeRequestDto requestDto) {
         ProductLikeCommand command = ProductLikeCommand.of(requestDto.getProductId(), requestDto.getMemberId());
+
         ProductLikeResult result = productLikeFacade.registerProductLike(command);
+
         return ApiResponse.success(ProductLikeResponseDto.of(result));
     }
 

--- a/apps/commerce-api/src/test/java/com/loopers/application/orders/OrderFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/orders/OrderFacadeIntegrationTest.java
@@ -13,6 +13,8 @@ import com.loopers.domain.couponmember.CouponMemberRepository;
 import com.loopers.domain.member.Member;
 import com.loopers.domain.member.MemberRepository;
 import com.loopers.domain.orders.OrderStatus;
+import com.loopers.domain.orders.Orders;
+import com.loopers.domain.orders.OrdersRepository;
 import com.loopers.domain.payment.CardType;
 import com.loopers.domain.payment.PaymentType;
 import com.loopers.domain.point.Point;
@@ -49,6 +51,9 @@ public class OrderFacadeIntegrationTest {
 
     @Autowired
     private CouponRepository couponRepository;
+
+    @Autowired
+    private OrdersRepository ordersRepository;
 
     @Autowired
     private CouponMemberRepository couponMemberRepository;
@@ -604,10 +609,13 @@ public class OrderFacadeIntegrationTest {
                     null
             );
 
-            // When & Then
-            Assertions.assertThrows(CoreException.class, () -> {
-                ordersFacade.placeOrder(placeOrderCommand);
-            });
+            // When
+            OrdersRegisterInfoResult ordersRegisterInfoResult = ordersFacade.placeOrder(placeOrderCommand);
+
+            Orders orders = ordersRepository.findById(ordersRegisterInfoResult.getOrdersId()).get();
+            // then
+            Assertions.assertEquals(ordersRegisterInfoResult.getOrderStatus(), OrderStatus.PENDING);
+            Assertions.assertEquals(orders.getOrderStatus(), OrderStatus.FAILED);
         }
 
         @DisplayName("상품의 재고가 부족하면 주문에 실패한다.")

--- a/apps/commerce-api/src/test/java/com/loopers/domain/orders/OrdersTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/orders/OrdersTest.java
@@ -24,14 +24,12 @@ class OrdersTest {
             Long memberId = null;
             int quantity = 2;
             BigDecimal totalPrice = BigDecimal.valueOf(1000);
-            Long couponMemberId = null;
-            boolean couponUsed = false;
             String orderKey = UUIDUtil.generateUUID();
 
 
             // when & then
             assertThrows(CoreException.class, () -> {
-                Orders.create(memberId, quantity, totalPrice, couponMemberId, couponUsed, orderKey);
+                Orders.create(memberId, quantity, totalPrice, orderKey);
             });
         }
 
@@ -42,14 +40,12 @@ class OrdersTest {
             Long memberId = 1L;
             int quantity = 0;
             BigDecimal totalPrice = BigDecimal.valueOf(1000);
-            Long couponMemberId = null;
-            boolean couponUsed = false;
             String orderKey = UUIDUtil.generateUUID();
 
 
             // when & then
             assertThrows(CoreException.class, () -> {
-                Orders.create(memberId, quantity, totalPrice, couponMemberId, couponUsed, orderKey);
+                Orders.create(memberId, quantity, totalPrice, orderKey);
             });
         }
 
@@ -60,13 +56,11 @@ class OrdersTest {
             Long memberId = 1L;
             int quantity = 2;
             BigDecimal totalPrice = BigDecimal.valueOf(100);
-            Long couponMemberId = null;
-            boolean couponUsed = false;
             String orderKey = UUIDUtil.generateUUID();
 
 
             // when
-            Orders orders = Orders.create(memberId, quantity, totalPrice, couponMemberId, couponUsed, orderKey);
+            Orders orders = Orders.create(memberId, quantity, totalPrice, orderKey);
 
             // then
             assertEquals(memberId, orders.getMemberId());


### PR DESCRIPTION
## 📌 Summary
1. 주문, 쿠폰사용, 재고차감, 결제호출을 각각의 프로세스로 분리.(이벤트 처리)
2. 좋아요, 좋아요 취소에 대한 이벤트 분리
3. 가능한 모든 이벤트 프로세스 로깅 진행

(회사일이 너무 바빠졌습니다. 이번에는 많은 시간을 투자하지 못했습니다.)
## 💬 Review Points
1. 절차적으로 처리하던 일을 전부 쪼개버리니 SRP적으로느 매우 좋다고 생각하였습니다. 하지만 트랜잭션 관리, 롤백 관리, 다양한 예외 케이스를 생각하다보니 개발이 많이 어려워지는 느낌이 들었습니다.
보통 길어지는 트랜잭션을 짧게 만들기 위해서 이벤트로 분리한다고 생각하는데, 이런 이벤트 분리가 당연한 것이라고 여겨야 할까요?
(트랜잭션 짧게 가져간다는 것에는 매우 동의하지만 그만큼 구현 난이도가 조금 있다고 생각하여 질문드립니다.)

2. 회사에서도 try, catch를 애용하는 편입니다. 주문을 분리하다보니 재고차감에서 문제가 발생하는 경우 주문까지 실패처리를 기록해야 했습니다. 이럴 경우 재고 이벤트 리스너에 try, catch를 걸고 catch에서 잡히면 별도의 서비스를 호출하여 주문 실패를 마킹했습니다.
이렇게 try, catch를 생각보다 자주 사용하시는 편인가요? 아니면 기존 데이터 상태를 처리하기 위한 또다른 방법이 있는지 궁금합니다.

3. 상세한 로깅?이라는 게 어떤 의미인지 잘 와닿지 않습니다.
회사에서도 외부 api를 타는 것들이 많은데 거의 대부분 필요한 곳에 log.info를 걸어두고 일단 로그 데이터를 다 찍어내고 있습니다. 그러면 추후 문제가 발생했을 때 모든 로그 데이터를 확인하여 조치를 취할 수 있다는 장점이 있다고 생각합니다.
(오늘도 로그덕분에 야근을 2시간밖에 하지 않았습니다.)
**이벤트 기반으로 유저의 행동 에 대해 서버 레벨에서 로깅하고, 추적할 방법을 고민해 봅니다.** 이 말이 의미하는 것이 실제로 로깅을 상세하게 해서 추적을 용이하게만 하면 된다는 의미로 말씀하신 건지 궁금합니다.


## ✅ Checklist
<!--
- [x]  **이벤트 기반**으로 주문 트랜잭션과 쿠폰 사용 처리를 분리한다.
- [x]  **이벤트 기반**으로 결제 결과에 따른 주문 처리를 분리한다.
- [x]  **이벤트 기반**으로 주문, 결제의 결과에 대한 데이터 플랫폼에 전송하는 후속처리를 진행한다.

### ❤️ 좋아요 ↔ 집계

- [x]  **이벤트 기반**으로 좋아요 처리와 집계를 분리한다.
- [x]  집계 로직의 성공/실패와 상관 없이, 좋아요 처리는 정상적으로 완료되어야 한다.

### 📽️ 공통

- [x]  이벤트 기반으로 `유저의 행동` 에 대해 서버 레벨에서 로깅하고, 추적할 방법을 고민해 봅니다.
    
    > *상품 조회, 클릭, 좋아요, 주문 등*
    > 
- [x]  동작의 주체를 적절하게 분리하고, 트랜잭션 간의 연관관계를 고민해 봅니다.
-->

## 📎 References